### PR TITLE
'symlinking' typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ virtualenv, the Python bindings for GTK won't be in your ``PYTHONPATH``.
 
 Unfortunately, you can't ``pip install`` GTK+ bindings, so you have to use a
 workaround. To make the system GTK+ bindings available to your virtualenv,
-symlinking the ``gi`` module from the system dist-packages directory into your
+symlink the ``gi`` module from the system dist-packages directory into your
 virtualenv's site-packages::
 
     For a Ubuntu 32bit system::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Python bindings for GTK won't be in your ``PYTHONPATH``.
 
 Unfortunately, you can't ``pip install`` GTK+ bindings, so you have to use a
 workaround. To make the system GTK+ bindings available to your virtualenv,
-symlinking the ``gi`` module from the system dist-packages directory into your
+symlink the ``gi`` module from the system dist-packages directory into your
 virtualenv's site-packages::
 
     $ cd $VIRTUAL_ENV/lib/python2.7/site-packages

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -213,7 +213,7 @@ environment`_ first, and installing toga in that virtual environment.
     a virtual environment.
 
     To make the system GTK+ bindings available to your virtualenv,
-    symlinking the `gi` module from the system dist-packages directory into your
+    symlink the `gi` module from the system dist-packages directory into your
     virtualenv's site-packages.
     
         For a Ubuntu 32bit system::


### PR DESCRIPTION
Same typo is also on http://pybee.org/toga/