### PR TITLE
Add extracted reference docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/reference/core.rst
+++ b/docs/reference/core.rst
@@ -4,6 +4,10 @@ Core Widgets
 
 
 App
+===
+
+.. autoclass:: toga.interface.app.App
+
 
 Container
 

--- a/toga/__init__.py
+++ b/toga/__init__.py
@@ -4,6 +4,10 @@ import sys
 
 from .constants import *
 
+# Work around import loop issues (toga -> platform -> toga.interface) import
+# all these things before we import the platform stuff
+import toga.interface.app
+
 __all__ = [
     '__version__',
     'platform'

--- a/toga/interface/app.py
+++ b/toga/interface/app.py
@@ -1,0 +1,30 @@
+class App(object):
+    '''Toga App
+
+    The App is the top level of any GUI program. It is the manager of all the
+    other bits of the GUI app: the main window and events that window generates
+    like user input.
+
+    When you create an App you need to provide it a name, an id for uniqueness
+    (by convention, the identifier is a "reversed domain name".) and an
+    optional startup function which should run once the App has initialised.
+    The startup function typically constructs some initial user interface.
+
+    Once the app is created you should invoke the main_loop() method, which
+    will hand over execution of your program to Toga to make the App interface
+    do its thing.
+
+    Here is the absolute minimum App::
+
+        app = toga.App('Empty App', 'org.pybee.empty')
+        app.main_loop()
+    '''
+    def __init__(self, name, app_id, icon=None, startup=None):
+        raise NotImplemented
+
+    def main_loop(self):
+        '''Invoke the application to handle user input.
+
+        This method typically only returns once the application is exiting.
+        '''
+        raise NotImplemented


### PR DESCRIPTION
This patch adds the ability to document the UI toolkit using
base abstract classes, and includes those docs in the reference
doc section.

There should be a related patch generated for each of the
implementations which bases their concrete UI components
off of the abstract provided here.

Signed-off-by: Richard Jones <r1chardj0n3s@gmail.com>