### PR TITLE
Toga Label not working on iOS

### DIFF
--- a/src/iOS/toga_iOS/widgets/label.py
+++ b/src/iOS/toga_iOS/widgets/label.py
@@ -30,5 +30,5 @@ class Label(LabelInterface, WidgetMixin):
         fitting_size = self._impl.systemLayoutSizeFittingSize_(CGSize(0, 0))
         self.style.hint(
             height=fitting_size.height,
-            width=(fitting_size.width, None)
+            width=fitting_size.width
         )


### PR DESCRIPTION
If you add a Label in iOS, the application crash with the exception:
```
  File "/Users/marc/Library/Developer/CoreSimulator/Devices/294E285B-2221-460A-B009-B2FFF9DB83D4/data/Containers/Bundle/Application/B2E6BC5C-4ECC-447D-810D-ACD19EFFE87D/Hello World.app/Library/Python.framework/Resources/lib/python3.5/site-packages/colosseum/layout.py", line 174, in _set_dimension_from_style
    if not self._dimension_is_defined(axis):
  File "/Users/marc/Library/Developer/CoreSimulator/Devices/294E285B-2221-460A-B009-B2FFF9DB83D4/data/Containers/Bundle/Application/B2E6BC5C-4ECC-447D-810D-ACD19EFFE87D/Hello World.app/Library/Python.framework/Resources/lib/python3.5/site-packages/colosseum/layout.py", line 110, in _dimension_is_defined
    return value is not None and value > 0
TypeError: unorderable types: tuple() > int()
```

The error seems to be in this line, but I am not sure if I understood correctly all the layout stuff :) I just compared this line in other widgets and cocoa implementation... and at the end, the app works with this patch.