### PR TITLE
Select the right Toga platform under Django

### DIFF
--- a/src/django/toga_django/django/__init__.py
+++ b/src/django/toga_django/django/__init__.py
@@ -3,9 +3,14 @@ import os
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
+import toga
+
 
 class TogaApp(AppConfig):
     name = 'toga'
     label = 'toga'
     verbose_name = _("Toga")
     path = os.path.dirname(__file__)
+
+    def ready(self):
+        toga.set_platform('toga_django')


### PR DESCRIPTION
When Toga is used under Django, the automatic platform detection is always wrong.

This adds a call to `toga.set_platform()` in the Django app's `ready()` -- I can somehow imagine one actually wanting the server platform even when this app is imported, but not if it is initialized by Django.

(baby steps, this is my first contribution to this awesome project)