### PR TITLE
Swap order of f_input and f_label in tutorial-1.rst

### DIFF
--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -31,8 +31,8 @@ Here's the source code::
 
         button = toga.Button('Calculate', on_press=calculate)
 
-        f_box.add(f_label)
         f_box.add(f_input)
+        f_box.add(f_label)
 
         c_box.add(join_label)
         c_box.add(c_input)


### PR DESCRIPTION
The order of f_input and f_label in the example code of tutorial-1.rst does not match the screenshot. This is what it looks like as is on Ubuntu:
![original](https://cloud.githubusercontent.com/assets/1214617/21900769/a73cd246-d8ba-11e6-8be4-cad7ef66335b.png)

This is what it looks like after swapping:
![swapped](https://cloud.githubusercontent.com/assets/1214617/21900782/b54aab2e-d8ba-11e6-805e-9490477caaf5.png)
