### PR TITLE
Fix mainBundle

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -89,7 +89,7 @@ class App(AppInterface):
 
         self._impl.setApplicationIconImage_(self.icon._impl)
 
-        self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle().bundlePath))
+        self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle.bundlePath))
 
         appDelegate = AppDelegate.alloc().init()
         appDelegate._interface = self


### PR DESCRIPTION
When running the toga-demo app and ever other toga-tutorial I got this error:

~~~
Traceback (most recent call last):
  File "/Users/Jonas/Documents/Programming/PyBee/my_test_apps/test_app_cocoa/main.py", line 20, in <module>
    app.main_loop()
  File "/Users/Jonas/Documents/Programming/PyBee/toga/src/cocoa/toga_cocoa/app.py", line 140, in main_loop
    self._startup()
  File "/Users/Jonas/Documents/Programming/PyBee/toga/src/cocoa/toga_cocoa/app.py", line 92, in _startup
    self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle().bundlePath))
TypeError: 'ObjCInstance' object is not callable
~~~

Apple Reference say mainBundle is a property not a function [docs](https://developer.apple.com/reference/foundation/nsbundle/1410786-mainbundle?language=objc).