### PR TITLE
Switch implementation for core, cocoa and iOS(label not working on iOS)

### DIFF
--- a/src/cocoa/toga_cocoa/__init__.py
+++ b/src/cocoa/toga_cocoa/__init__.py
@@ -19,6 +19,7 @@ from .widgets.passwordinput import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
 from .widgets.splitcontainer import *
+from .widgets.switch import *
 from .widgets.table import *
 from .widgets.textinput import *
 from .widgets.tree import *
@@ -46,6 +47,7 @@ __all__ = [
     'ScrollContainer',
     'Selection',
     'SplitContainer',
+    'Switch',
     'Table',
     'TextInput',
     'Tree',

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -56,6 +56,10 @@ NSWindow = ObjCClass('NSWindow')
 # NSButton.h
 NSButton = ObjCClass('NSButton')
 
+NSOnState = 1
+NSOffState = 0
+NSMixedState = -1
+
 # NSButtonCell.h
 NSMomentaryLightButton = 0
 NSPushOnPushOffButton = 1

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -10,13 +10,13 @@ from ..utils import process_callback
 class TogaSwitch(NSButton):
     @objc_method
     def onPress_(self, obj) -> None:
-        if self._interface.on_press:
-            process_callback(self._interface.on_press(self._interface))
+        if self._interface.on_toggle:
+            process_callback(self._interface.on_toggle(self._interface))
 
 
 class Switch(SwitchInterface, WidgetMixin):
-    def __init__(self, label, id=None, style=None, on_press=None, state=False):
-        super().__init__(label, id=id, style=style, on_press=on_press, state=state)
+    def __init__(self, label, id=None, style=None, on_toggle=None, is_on=False):
+        super().__init__(label, id=id, style=style, on_toggle=on_toggle, is_on=is_on)
         self._create()
 
     def create(self):
@@ -35,20 +35,35 @@ class Switch(SwitchInterface, WidgetMixin):
         self._impl.setTitle_(self.label)
         self.rehint()
 
-    def _set_state(self, value):
+    def _set_is_on(self, value):
         if value is True:
             self._impl.state = NSOnState
         elif value is False:
             self._impl.state = NSOffState
 
-    def _get_state(self):
-        state = self._impl.state
-        if state == 1:
+    def _get_is_on(self):
+        is_on = self._impl.state
+        if is_on == 1:
             return True
-        elif state == 0:
+        elif is_on == 0:
             return False
         else:
-            raise Exception('Undefined state of {}'.format(__class__))
+            raise Exception('Undefined value for is_on of {}'.format(__class__))
+
+    def _set_enabled(self, value):
+        if value is True:
+            self._impl.enabled = True
+        elif value is False:
+            self._impl.enabled = False
+
+    def _get_enabled(self):
+        enabled = self._impl.isEnabled()
+        if enabled == 1:
+            return True
+        elif enabled == 0:
+            return False
+        else:
+            raise Exception('Undefined value for enabled of {}'.format(__class__))
 
     def rehint(self):
         fitting_size = self._impl.fittingSize()

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -1,0 +1,58 @@
+from rubicon.objc import objc_method, get_selector
+
+from toga.interface import Switch as SwitchInterface
+
+from .base import WidgetMixin
+from ..libs import *
+from ..utils import process_callback
+
+
+class TogaSwitch(NSButton):
+    @objc_method
+    def onPress_(self, obj) -> None:
+        if self._interface.on_press:
+            process_callback(self._interface.on_press(self._interface))
+
+
+class Switch(SwitchInterface, WidgetMixin):
+    def __init__(self, label, id=None, style=None, on_press=None, state=False):
+        super().__init__(label, id=id, style=style, on_press=on_press, state=state)
+        self._create()
+
+    def create(self):
+        self._impl = TogaSwitch.alloc().init()
+        self._impl._interface = self
+
+        self._impl.setBezelStyle_(NSRoundedBezelStyle)
+        self._impl.setButtonType_(NSSwitchButton)
+        self._impl.setTarget_(self._impl)
+        self._impl.setAction_(get_selector('onPress:'))
+
+        # Add the layout constraints
+        self._add_constraints()
+
+    def _set_label(self, label):
+        self._impl.setTitle_(self.label)
+        self.rehint()
+
+    def _set_state(self, value):
+        if value is True:
+            self._impl.state = NSOnState
+        elif value is False:
+            self._impl.state = NSOffState
+
+    def _get_state(self):
+        state = self._impl.state
+        if state == 1:
+            return True
+        elif state == 0:
+            return False
+        else:
+            raise Exception('Undefined state of {}'.format(__class__))
+
+    def rehint(self):
+        fitting_size = self._impl.fittingSize()
+        self.style.hint(
+            height=fitting_size.height,
+            min_width=fitting_size.width,
+        )

--- a/src/core/toga/interface/__init__.py
+++ b/src/core/toga/interface/__init__.py
@@ -18,6 +18,7 @@ from .widgets.optioncontainer import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
 from .widgets.splitcontainer import *
+from .widgets.switch import *
 from .widgets.table import *
 from .widgets.textinput import *
 from .widgets.tree import *
@@ -49,6 +50,7 @@ __all__ = [
     'ScrollContainer',
     'Selection',
     'SplitContainer',
+    'Switch',
     'NumberInput',
     'Table',
     'TextInput',

--- a/src/core/toga/interface/widgets/switch.py
+++ b/src/core/toga/interface/widgets/switch.py
@@ -55,7 +55,7 @@ class Switch(Widget):
         self.rehint()
 
     def _set_label(self, value):
-        raise NotImplementedError('The inheriting class of {} must define _set_label()')
+        raise NotImplementedError('The inheriting class of {} must define _set_label()'.format(__class__))
 
     @property
     def on_toggle(self):

--- a/src/core/toga/interface/widgets/switch.py
+++ b/src/core/toga/interface/widgets/switch.py
@@ -1,0 +1,102 @@
+from .base import Widget
+
+
+class Switch(Widget):
+    """
+    Switch widget, a clickable button with two stable states, True (on, checked) and False (off, unchecked)
+
+    :param label:       Text to be shown next to the Switch
+    :type label:        ``str``
+
+    :param id:          An identifier for this widget.
+    :type  id:          ``str``
+
+    :param style:       an optional style object. If no style is provided then a
+                        new one will be created for the widget.
+    :type style:        :class:`colosseum.CSSNode`
+
+    :param on_press:    Function to execute when pressed
+    :type on_press:     ``callable``
+
+    :param state        Current state of the Switch
+    :type state         ``Bool`
+    """
+
+    def __init__(self, label, id=None, style=None, on_press=None, state=False):
+        super().__init__(id=id, style=style, label=label, on_press=on_press, state=state)
+
+    def _configure(self, label, on_press, state):
+        self.label = label
+        self.on_press = on_press
+        self.state = state
+
+    @property
+    def label(self):
+        '''
+        :returns: The label value
+        :rtype: ``str``
+        '''
+        return self._label
+
+    @label.setter
+    def label(self, value):
+        '''
+        Set the label value
+
+        :param value: The new label value
+        :type  value: ``str``
+        '''
+        if value is None:
+            self._label = ''
+        else:
+            self._label = str(value)
+        self._set_label(value)
+        self.rehint()
+
+    def _set_label(self, value):
+        raise NotImplementedError('The inheriting class of {} must define _set_label()')
+
+    @property
+    def on_press(self):
+        '''
+        The callable function for when the switch is pressed
+
+        :rtype: ``callable``
+        '''
+        return self._on_press
+
+    @on_press.setter
+    def on_press(self, handler):
+        self._on_press = handler
+        self._set_on_press(handler)
+
+    def _set_on_press(self, value):
+        pass
+
+    @property
+    def state(self):
+        '''
+        :returns: The state value
+
+        :rtype: ``Bool``
+        '''
+        return self._get_state()
+
+    @state.setter
+    def state(self, value):
+        '''
+        Set the state value
+
+        :param value: The new state value
+        :type  value: ``Bool``
+        '''
+        if value is True:
+            self._set_state(True)
+        elif value is False:
+            self._set_state(False)
+
+    def _set_state(self, value):
+        raise NotImplementedError('The inheriting class of {} must define _set_state()'.format(__class__))
+
+    def _get_state(self):
+        raise NotImplementedError('The inheriting class of {} must define _get_state()'.format(__class__))

--- a/src/core/toga/interface/widgets/switch.py
+++ b/src/core/toga/interface/widgets/switch.py
@@ -5,7 +5,7 @@ class Switch(Widget):
     """
     Switch widget, a clickable button with two stable states, True (on, checked) and False (off, unchecked)
 
-    :param label:       Text to be shown next to the Switch
+    :param label:       Text to be shown next to the switch
     :type label:        ``str``
 
     :param id:          An identifier for this widget.
@@ -15,37 +15,38 @@ class Switch(Widget):
                         new one will be created for the widget.
     :type style:        :class:`colosseum.CSSNode`
 
-    :param on_press:    Function to execute when pressed
-    :type on_press:     ``callable``
+    :param on_toggle:    Function to execute when pressed
+    :type on_toggle:     ``callable``
 
-    :param state        Current state of the Switch
-    :type state         ``Bool`
+    :param is_on        Current on or off state of the switch
+    :type is_on         ``Bool`
     """
 
-    def __init__(self, label, id=None, style=None, on_press=None, state=False):
-        super().__init__(id=id, style=style, label=label, on_press=on_press, state=state)
+    def __init__(self, label, id=None, style=None, on_toggle=None, is_on=False, enabled=True):
+        super().__init__(id=id, style=style, label=label, on_toggle=on_toggle, is_on=is_on, enabled=enabled)
 
-    def _configure(self, label, on_press, state):
+    def _configure(self, label, on_toggle, is_on, enabled):
         self.label = label
-        self.on_press = on_press
-        self.state = state
+        self.on_toggle = on_toggle
+        self.is_on = is_on
+        self.enabled = enabled
 
     @property
     def label(self):
-        '''
+        """
         :returns: The label value
         :rtype: ``str``
-        '''
+        """
         return self._label
 
     @label.setter
     def label(self, value):
-        '''
+        """
         Set the label value
 
         :param value: The new label value
         :type  value: ``str``
-        '''
+        """
         if value is None:
             self._label = ''
         else:
@@ -57,46 +58,74 @@ class Switch(Widget):
         raise NotImplementedError('The inheriting class of {} must define _set_label()')
 
     @property
-    def on_press(self):
-        '''
+    def on_toggle(self):
+        """
         The callable function for when the switch is pressed
 
         :rtype: ``callable``
-        '''
-        return self._on_press
+        """
+        return self._on_toggle
 
-    @on_press.setter
-    def on_press(self, handler):
-        self._on_press = handler
-        self._set_on_press(handler)
+    @on_toggle.setter
+    def on_toggle(self, handler):
+        self._on_toggle = handler
+        self._set_on_toggle(handler)
 
-    def _set_on_press(self, value):
+    def _set_on_toggle(self, value):
         pass
 
     @property
-    def state(self):
-        '''
-        :returns: The state value
+    def is_on(self):
+        """
+        :returns: The is_on value
 
         :rtype: ``Bool``
-        '''
-        return self._get_state()
+        """
+        return self._get_is_on()
 
-    @state.setter
-    def state(self, value):
-        '''
-        Set the state value
+    @is_on.setter
+    def is_on(self, value):
+        """
+        Set the is_on value
 
-        :param value: The new state value
+        :param value: The new is_on value
         :type  value: ``Bool``
-        '''
+        """
         if value is True:
-            self._set_state(True)
+            self._set_is_on(True)
         elif value is False:
-            self._set_state(False)
+            self._set_is_on(False)
 
-    def _set_state(self, value):
-        raise NotImplementedError('The inheriting class of {} must define _set_state()'.format(__class__))
+    @property
+    def enabled(self):
+        """
+        :returns: The enabled state of the switch
 
-    def _get_state(self):
-        raise NotImplementedError('The inheriting class of {} must define _get_state()'.format(__class__))
+        :rtype  value: ``Bool``
+        """
+        return self._get_enabled()
+
+    @enabled.setter
+    def enabled(self, value):
+        """
+        Set the enabled state of the switch
+
+        :param value: The new enabled value
+        :type  value: ``Bool``
+        """
+        if value is True:
+            self._set_enabled(True)
+        elif value is False:
+            self._set_enabled(False)
+
+    def _set_is_on(self, value):
+        raise NotImplementedError('The inheriting class of {} must define _set_is_on()'.format(__class__))
+
+    def _get_is_on(self):
+        raise NotImplementedError('The inheriting class of {} must define _get_is_on()'.format(__class__))
+
+    def _set_enabled(self, value):
+        raise NotImplementedError('The inheriting class of {} must define _set_enabled()'.format(__class__))
+
+    def _get_enabled(self):
+        raise NotImplementedError('The inheriting class of {} must define _get_enabled()'.format(__class__))

--- a/src/iOS/toga_iOS/__init__.py
+++ b/src/iOS/toga_iOS/__init__.py
@@ -21,6 +21,7 @@ from .widgets.navigationview import *
 # from .widgets.progressbar import *
 # from .widgets.scrollcontainer import *
 # from .widgets.splitcontainer import *
+from .widgets.switch import *
 # from .widgets.table import *
 from .widgets.textinput import *
 # from .widgets.tree import *
@@ -46,6 +47,7 @@ __all__ = [
     # 'ProgressBar',
     # 'ScrollContainer',
     # 'SplitContainer',
+    'Switch',
     # 'Table',
     'TextInput',
     # 'Tree',

--- a/src/iOS/toga_iOS/libs/uikit.py
+++ b/src/iOS/toga_iOS/libs/uikit.py
@@ -257,3 +257,6 @@ UITextBorderStyleRoundedRect = 3
 
 # UIWebView.h
 UIWebView = ObjCClass('UIWebView')
+
+# UISwitch.h
+UISwitch = ObjCClass('UISwitch')

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -9,13 +9,13 @@ from ..libs import *
 class TogaSwitch(UISwitch):
     @objc_method
     def onPress_(self, obj) -> None:
-        if self._interface.on_press:
-            self._interface.on_press(self._interface)
+        if self._interface.on_toggle:
+            self._interface.on_toggle(self._interface)
 
 
 class Switch(SwitchInterface, WidgetMixin):
-    def __init__(self, label, id=None, on_press=None, style=None, state=False):
-        super().__init__(label, id=id, style=style, on_press=on_press, state=state)
+    def __init__(self, label, id=None, on_toggle=None, style=None, is_on=False):
+        super().__init__(label, id=id, style=style, on_toggle=on_toggle, is_on=is_on)
         self._create()
 
     def create(self):
@@ -30,11 +30,26 @@ class Switch(SwitchInterface, WidgetMixin):
     def _set_label(self, value):
         Warning('{} does not implement the label functionality at the moment.'.format(__class__))
 
-    def _set_state(self, value):
+    def _set_is_on(self, value):
         self._impl.setOn_animated_(value, True)
 
-    def _get_state(self):
+    def _get_is_on(self):
         return self._impl.isOn()
+
+    def _set_enabled(self, value):
+        if value is True:
+            self._impl.enabled = True
+        elif value is False:
+            self._impl.enabled = False
+
+    def _get_enabled(self):
+        enabled = self._impl.isEnabled()
+        if enabled == 1:
+            return True
+        elif enabled == 0:
+            return False
+        else:
+            raise Exception('Undefined value for enabled of {}'.format(__class__))
 
     def rehint(self):
         fitting_size = self._impl.systemLayoutSizeFittingSize_(CGSize(0, 0))

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -1,0 +1,44 @@
+from rubicon.objc import objc_method
+
+from toga.interface import Switch as SwitchInterface
+
+from .base import WidgetMixin
+from ..libs import *
+
+
+class TogaSwitch(UISwitch):
+    @objc_method
+    def onPress_(self, obj) -> None:
+        if self._interface.on_press:
+            self._interface.on_press(self._interface)
+
+
+class Switch(SwitchInterface, WidgetMixin):
+    def __init__(self, label, id=None, on_press=None, style=None, state=False):
+        super().__init__(label, id=id, style=style, on_press=on_press, state=state)
+        self._create()
+
+    def create(self):
+        self._impl = TogaSwitch.alloc().init()
+        self._impl._interface = self
+
+        self._impl.addTarget_action_forControlEvents_(self._impl, get_selector('onPress:'), UIControlEventValueChanged)
+
+        # Add the layout constraints
+        self._add_constraints()
+
+    def _set_label(self, value):
+        Warning('{} does not implement the label functionality at the moment.'.format(__class__))
+
+    def _set_state(self, value):
+        self._impl.setOn_animated_(value, True)
+
+    def _get_state(self):
+        return self._impl.isOn()
+
+    def rehint(self):
+        fitting_size = self._impl.systemLayoutSizeFittingSize_(CGSize(0, 0))
+        self.style.hint(
+            height=fitting_size.height,
+            min_width=fitting_size.width,
+        )

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -19,31 +19,39 @@ class Switch(SwitchInterface, WidgetMixin):
         self._create()
 
     def create(self):
-        self._impl = TogaSwitch.alloc().init()
+        # Hack! Because UISwitch has no label, we place it in a UITableViewCell to get a label
+        self._impl = UITableViewCell.alloc().initWithStyle_reuseIdentifier_(UITableViewCellStyleDefault, 'row')
         self._impl._interface = self
 
-        self._impl.addTarget_action_forControlEvents_(self._impl, get_selector('onPress:'), UIControlEventValueChanged)
+        self._impl_switch = TogaSwitch.alloc().init()
+        self._impl_switch._interface = self
+        self._impl_switch.addTarget_action_forControlEvents_(self._impl_switch, get_selector('onPress:'),
+                                                             UIControlEventValueChanged)
+        # Add Switch to UITableViewCell
+        self._impl.accessoryView = self._impl_switch
 
         # Add the layout constraints
         self._add_constraints()
 
     def _set_label(self, value):
-        Warning('{} does not implement the label functionality at the moment.'.format(__class__))
+        self._impl.textLabel.text = str(value)
 
     def _set_is_on(self, value):
-        self._impl.setOn_animated_(value, True)
+        self._impl_switch.setOn_animated_(value, True)
 
     def _get_is_on(self):
-        return self._impl.isOn()
+        return self._impl_switch.isOn()
 
     def _set_enabled(self, value):
         if value is True:
-            self._impl.enabled = True
+            self._impl.textLabel.enabled = True
+            self._impl.accessoryView.enabled = True
         elif value is False:
-            self._impl.enabled = False
+            self._impl.textLabel.enabled = False
+            self._impl.accessoryView.enabled = False
 
     def _get_enabled(self):
-        enabled = self._impl.isEnabled()
+        enabled = self._impl.accessoryView.isEnabled()
         if enabled == 1:
             return True
         elif enabled == 0:


### PR DESCRIPTION
@freakboy3742 I know we talked about not including the switch widget as a normal widget but only through the settings api. But on my settings-api-journey I found out that for macOS and iOS you have to (if you don't manage all the settings in the settings app what basically every normal app does) provide your own settings and therefor you need to be able to create your own switch widget.

- macOS work
- iOS switch has no label by default this is because it should only appear in a UITable​View​Cell with a label. I found some apps that use a switch with a label in a single UITable​View​Cell without a UITabelView wrapped around it and they say it is no problem. If I get your ok I would try to implement this into the iOS switch integration. The iOS switch functionality works already. 


Here a little demo program if you would like to take it for a spin.
~~~python
import time
import toga
from colosseum import CSS


def build(app):
    def callback(widget):
        label.text = 'Switch State: {}'.format(widget.state)

    def btn_callback(widget):
        switch.label = str('Update Label: {}'.format(time.time()))
        if switch.state:
            switch.state = False
        else:
            switch.state = True
        label.text = 'Switch State: {}'.format(switch.state)

    switch = toga.Switch('My Switch', on_press=callback)
    button = toga.Button('My Button', on_press=btn_callback, style=CSS(width=200))
    label = toga.Label('Switch State: {}'.format(switch.state))

    style = CSS(flex=1, padding=10)
    box = toga.Box(style=style)
    box.add(switch)
    box.add(button)
    box.add(label)
    return box


if __name__ == '__main__':
    app = toga.App('Test Switch', 'org.pybee.helloworld', startup=build)
    app.main_loop()
~~~

Signed-off-by: Jonas Schell <jonasschell@ocupe.org>