### PR TITLE
Fixed rehinting on GTK to get rid of:

### DIFF
--- a/src/gtk/toga_gtk/container.py
+++ b/src/gtk/toga_gtk/container.py
@@ -33,6 +33,8 @@ class CSSLayout(Gtk.Fixed):
         # print(self._interface, "Container layout", allocation.width, 'x', allocation.height, ' @ ', allocation.x, 'x', allocation.y)
         self.set_allocation(allocation)
 
+        self._interface.content.rehint()
+
         # Force a re-layout of widgets
         self._interface.content._update_layout(
             width=allocation.width,

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -28,3 +28,7 @@ class WidgetMixin:
 
     def _set_font(self, font):
         self._impl.override_font(font._impl)
+
+    def rehint(self):
+        for c in self.children:
+            c.rehint()

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -11,6 +11,3 @@ class Box(BoxInterface, WidgetMixin):
 
     def create(self):
         pass
-
-    def rehint(self):
-        pass

--- a/src/gtk/toga_gtk/widgets/splitcontainer.py
+++ b/src/gtk/toga_gtk/widgets/splitcontainer.py
@@ -45,9 +45,6 @@ class SplitContainer(SplitContainerInterface, WidgetMixin):
     def _set_direction(self, value):
         pass
 
-    def rehint(self):
-        pass
-
     def _update_child_layout(self):
         """Force a layout update on the widget.
         """


### PR DESCRIPTION
(toga-demo:23072): Gtk-WARNING **: Allocating size to GtkButton 0x558d3783fa40 without calling gtk_widget_get_preferred_width/height(). How does the code know the size to allocate?