### PR TITLE
Fix autodoc in the RTD builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+future
+colosseum


### PR DESCRIPTION
Currently, the RTD autodoc build fails for two reasons: a) because the build uses Python 2.7 and `builtins` import fails, and b) because the `colosseum` import fails.

The first problem can be fixed by editing the RTD `Advanced Settings` and changing the Python **Python interpreter** setting to **CPython 3.x**.

The second problem can be fixed by adding a `requirements.txt` with the `colosseum` dependency (this PR), and editing the RTD `Advanced Settings`, enabling *Install your project inside a virtualenv using setup.py install* and setting **Requirements file** to `docs/requirements.txt`.