### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ If these requirements aren't met, Toga either won't work at all, or won't have
 full functionality.
 
 Quickstart
-~~~~~~~~~~~~~
+~~~~~~~~~~
 
 To get a demonstration of the capabilities of Toga, run the following::
 
@@ -54,7 +54,7 @@ Documentation
 Documentation for Toga can be found on `Read The Docs`_.
 
 Community
-~~~~~~~~~~~~~
+~~~~~~~~~
 
 Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
@@ -63,7 +63,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 * The `pybee/general`_ channel on Gitter.
 
 Contributing
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 If you experience problems with Toga, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,6 +178,13 @@ html_static_path = ['_static']
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'togadoc'
 
+try:
+    import sphinx_rtd_theme
+    html_theme = "sphinx_rtd_theme"
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+except ImportError:
+    # The sphinx-rtd-theme package is not installed, so to the default
+    pass
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -27,7 +27,7 @@ Here's the source code
 
 Here are the :download:`Icons <./resources/icons.zip>`
 
-In this example, we see a couple of new Toga widgets - ``Table``,
-``SplitContainer``, and ``ScrollContainer``. You can also see that
+In this example, we see a couple of new Toga widgets - :class:`.Table`,
+:class:`.SplitContainer`, and :class:`.ScrollContainer`. You can also see that
 CSS styles can be added in the widget constructor. Lastly, you can
 see that windows can have toolbars.


### PR DESCRIPTION
1. Add links to the classes in the text at the bottom of the second tutorial
2. Update conf.py to use the sphinx-rtd-theme if can be imported so the documentation can built and tested locally.
3. Fix the headers in the Readme to not be beyond the header text.