### PR TITLE
Content and retry status on the window interface

### DIFF
--- a/src/core/toga/interface/window.py
+++ b/src/core/toga/interface/window.py
@@ -217,8 +217,9 @@ class Window:
     def error_dialog(self, title, message):
         return self._DIALOG_MODULE.error(self, title, message)
 
-    def stack_trace_dialog(self, title, message):
-        return self._DIALOG_MODULE.stack_trace(self, title, message)
+    def stack_trace_dialog(self, title, message, content, retry=False):
+        return self._DIALOG_MODULE.stack_trace(self, title, message,
+                                                content, retry)
 
     def save_file_dialog(self, title, suggested_filename, file_types):
         return self._DIALOG_MODULE.save_file(self, title, suggested_filename,


### PR DESCRIPTION
On toga_cocoa/dialogs requires content and retry status to create the dialog window, so I add on the interface to allow the passage of them.