### PR TITLE
fix for getting the length of the filenames array

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -49,8 +49,7 @@ class AppDelegate(NSObject):
 
     @objc_method
     def application_openFiles_(self, app, filenames) -> None:
-        # print("open file ", filenames)
-        for i in range(0, filenames.count):
+        for i in range(0, len(filenames)):
             filename = filenames.objectAtIndex(i)
             if isinstance(filename, str):
                 fileURL = NSURL.fileURLWithPath(filename)


### PR DESCRIPTION
The issue is discussed [here](https://github.com/pybee/rubicon-objc/issues/46) and leads to the following error:

~~~
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 234, in 'calling callback function'
  File "/Users/Jonas/Documents/Programming/PyBee/rubicon-objc/rubicon/objc/objc.py", line 1069, in _objc_method
    result = f(py_self, *args)
  File "/Users/Jonas/Documents/Programming/PyBee/toga/src/cocoa/toga_cocoa/app.py", line 53, in application_openFiles_
    for i in range(0, filenames.count):
TypeError: 'method' object cannot be interpreted as an integer
~~~