### PR TITLE
Adds an on_load listener and method to retrieve DOM.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -9,8 +9,8 @@ from ..libs import *
 class TogaWebView(WebView):
     @objc_method
     def webView_didFinishLoadForFrame_(self, sender, frame) -> None:
-        # print ("FINISHED LOADING")
-        pass
+        if self._interface.on_webview_load:
+            self._interface.on_webview_load(self._interface)
 
     @objc_method
     def acceptsFirstResponder(self) -> bool:
@@ -23,8 +23,8 @@ class TogaWebView(WebView):
 
 
 class WebView(WebViewInterface, WidgetMixin):
-    def __init__(self, id=None, style=None, url=None, on_key_down=None):
-        super().__init__(id=id, style=style, url=url, on_key_down=on_key_down)
+    def __init__(self, id=None, style=None, url=None, on_key_down=None, on_webview_load=None):
+        super().__init__(id=id, style=style, url=url, on_key_down=on_key_down, on_webview_load=on_webview_load)
         self._create()
 
     def create(self):
@@ -39,6 +39,12 @@ class WebView(WebViewInterface, WidgetMixin):
 
         # Add the layout constraints
         self._add_constraints()
+
+    def _get_dom(self):
+        # Utilises Step 2) of:
+        # https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/DisplayWebContent/Tasks/SaveAndLoad.html
+        html = self._impl.mainFrame.DOMDocument.documentElement.outerHTML ##domDocument.markupString
+        return html
 
     def _set_url(self, value):
         if value:

--- a/src/core/toga/interface/widgets/webview.py
+++ b/src/core/toga/interface/widgets/webview.py
@@ -5,7 +5,7 @@ class WebView(Widget):
     '''
     Web view widget
     '''
-    def __init__(self, id=None, style=None, url=None, on_key_down=None):
+    def __init__(self, id=None, style=None, url=None, on_key_down=None, on_webview_load=None):
         '''
         Instantiate a new instance of the tree widget
 
@@ -15,28 +15,41 @@ class WebView(Widget):
         :param style:       an optional style object. If no style is provided then a
                             new one will be created for the widget.
         :type style:        :class:`colosseum.CSSNode`
-        
+
         :param url: The URL to start with
         :type  url: ``str``
-        
+
         :param on_key_down: The callback method for when the a key is pressed within
             the web view
         :type  on_key_down: ``callable``
-        '''
-        super(WebView, self).__init__(id=id, style=style, url=url, on_key_down=on_key_down)
 
-    def _configure(self, url, on_key_down):
+        :param on_webview_load: The callback method for when the webview loads (or reloads)
+        :type  on_webview_load: ``callable``
+        '''
+        super(WebView, self).__init__(id=id, style=style, url=url, on_key_down=on_key_down, on_webview_load=None)
+
+    def _configure(self, url, on_key_down, on_webview_load=None):
         self.url = url
         self.on_key_down = on_key_down
+        self.on_webview_load = on_webview_load
 
     @property
     def url(self):
         '''
         The current URL
-        
+
         :rtype: ``str``
         '''
         return self._url
+
+    @property
+    def dom(self):
+        '''
+        The current DOM
+
+        :rtype: ``str``
+        '''
+        return self._get_dom()
 
     @url.setter
     def url(self, value):
@@ -46,10 +59,10 @@ class WebView(Widget):
     def set_content(self, root_url, content):
         '''
         Set the content of the web view
-        
+
         :param root_url: The URL
         :type  root_url: ``str``
-        
+
         :param content: The new content
         :type  content: ``str``
         '''
@@ -59,13 +72,16 @@ class WebView(Widget):
     def _set_url(self, value):
         raise NotImplementedError('Webview widget must define _set_url()')
 
+    def _get_dom(self, value):
+        raise NotImplementedError('Webview widget must define _get_dom()')
+
     def _set_content(self, root_url, content):
         raise NotImplementedError('Webview widget must define _set_content()')
 
     def evaluate(self, javascript):
         '''
         Evaluate a JavaScript expression
-        
+
         :param javascript: The javascript expression
         :type  javascript: ``str``
         '''


### PR DESCRIPTION
Cocoa binding uses the webview's document model to retrieve the DOM as a string. Other platforms NYI. on_load event notifies the event listener but it is up to the listener to retrieve url/DOM from the widget.