### PR TITLE
Add virtual exclude for project local virtualenv and PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ _build
 distribute-*
 docs/env
 local
+venv
+.idea
 .tox
 node_modules
 README.md


### PR DESCRIPTION
To prevent accidentally adding files from developer tools.