### PR TITLE
Add simple info dialog for Android app

### DIFF
--- a/src/android/toga_android/dialogs.py
+++ b/src/android/toga_android/dialogs.py
@@ -1,1 +1,38 @@
 
+
+class TogaAlertDialogBuilder(extends=android.app.AlertDialog[Builder]):
+    @super({context: android.content.Context})
+    def __init__(self, context, message):
+        self.setMessage(message)
+
+
+def info(window, title, message):
+    builder = TogaAlertDialogBuilder(window.app._impl, message)
+    builder.setPositiveButton("OK", None)
+    dialog = builder.create()
+    dialog.show()
+
+
+def question(window, title, message):
+    # TODO
+    raise NotImplementedError()
+
+
+def confirm(window, title, message):
+    # TODO
+    raise NotImplementedError()
+
+
+def error(window, title, message):
+    # TODO
+    raise NotImplementedError()
+
+
+def stack_trace(window, title, message, content, retry=False):
+    # TODO
+    raise NotImplementedError()
+
+
+def save_file(window, title, suggested_filename, file_types):
+    # TODO
+    raise NotImplementedError()


### PR DESCRIPTION
Signed-off-by: Elias Dorneles <eliasdorneles@gmail.com>

This adds the `info` dialog for Android, inspired on https://github.com/pybee/toga/blob/master/src/cocoa/toga_cocoa/dialogs.py .

The next dialogs will need a bit more thinking, since the functions need to return the a boolean indicating the user decision, and the Android Dialog API is async (one gotta register listeners to execute actions when a button is clicked).