### PR TITLE
Fix Widget Args format

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -10,7 +10,7 @@ class NumberInput(Widget):
         style (:class:`colosseum.CSSNode`):  an optional style object.
             If no style is provided then a new one will be created for the widget.
         factory (:obj:`module`): A python module that is capable to return a
-        implementation of this class with the same name. (optional & normally not needed)
+            implementation of this class with the same name. (optional & normally not needed)
 
         min_value (int): Minimum value (default 0)
         max_value (int): Maximum value (default 100)

--- a/src/core/toga/widgets/selection.py
+++ b/src/core/toga/widgets/selection.py
@@ -7,7 +7,7 @@ class Selection(Widget):
     Args:
         id (str): An identifier for this widget.
         style ( :class:`colosseum.CSSNode`): An optional style object.
-        If no style is provided then a new one will be created for the widget.
+            If no style is provided then a new one will be created for the widget.
         items (``list`` of ``str``): The items for the selection.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)


### PR DESCRIPTION
 Reference documentation was not generating properly because they were missing indentation