### PR TITLE
Callbacks with more than one arg.

### DIFF
--- a/src/core/toga/utils/handlers.py
+++ b/src/core/toga/utils/handlers.py
@@ -35,11 +35,11 @@ def wrapped_handler(interface, handler):
     the original handler function on the `_raw` attribute.
     """
     if handler:
-        def _handler(widget, **extra):
+        def _handler(widget, *args, **extra):
             if asyncio.iscoroutinefunction(handler):
-                asyncio.async(handler(interface, **extra))
+                asyncio.async(handler(interface, *args, **extra))
             else:
-                result = handler(interface, **extra)
+                result = handler(interface, *args, **extra)
                 if inspect.isgenerator(result):
                     asyncio.async(long_running_task(result))
                 else:


### PR DESCRIPTION
Allow callbacks to return more than just the interface.
Callbacks like this are possible:
~~~python
def on_select(interface, row):
    pass
~~~

I think callbacks like this could be more user friendly but I'm also ok with us not allowing them.

