### PR TITLE
Fix interface error in GTK Font

### DIFF
--- a/src/core/tests/test_font.py
+++ b/src/core/tests/test_font.py
@@ -5,4 +5,20 @@ import toga_dummy
 
 
 class TestFont(unittest.TestCase):
-    pass
+
+
+    def setUp(self):
+      
+      self.family = "sans-serif"
+      self.size = 14
+
+      self.font = toga.Font(self.family, 
+                            self.size)
+      print(self.font)
+
+    def test_family(self):
+      self.assertEqual(self.font.family, self.family)
+
+
+    def test_size(self):
+      self.assertEqual(self.font.size, self.size)

--- a/src/core/tests/test_font.py
+++ b/src/core/tests/test_font.py
@@ -5,4 +5,17 @@ import toga_dummy
 
 
 class TestFont(unittest.TestCase):
-    pass
+    def setUp(self):
+        self.family = "sans-serif"
+        self.size = 14
+
+        self.font = toga.Font(
+            self.family,
+            self.size
+        )
+
+    def test_family(self):
+      self.assertEqual(self.font.family, self.family)
+
+    def test_size(self):
+      self.assertEqual(self.font.size, self.size)

--- a/src/core/tests/test_font.py
+++ b/src/core/tests/test_font.py
@@ -6,12 +6,18 @@ import toga_dummy
 
 class TestFont(unittest.TestCase):
     def setUp(self):
+        mock_font = MagicMock(spec=toga_dummy.factory.Font)
+        
+        self.factory = MagicMock()
+        self.factory.Font = MagicMock(return_value=mock_font)
+
         self.family = "sans-serif"
         self.size = 14
 
         self.font = toga.Font(
             self.family,
-            self.size
+            self.size,
+            factory=self.factory
         )
 
     def test_family(self):

--- a/src/core/tests/test_font.py
+++ b/src/core/tests/test_font.py
@@ -5,20 +5,4 @@ import toga_dummy
 
 
 class TestFont(unittest.TestCase):
-
-
-    def setUp(self):
-      
-      self.family = "sans-serif"
-      self.size = 14
-
-      self.font = toga.Font(self.family, 
-                            self.size)
-      print(self.font)
-
-    def test_family(self):
-      self.assertEqual(self.font.family, self.family)
-
-
-    def test_size(self):
-      self.assertEqual(self.font.size, self.size)
+    pass

--- a/src/core/toga/font.py
+++ b/src/core/toga/font.py
@@ -2,7 +2,7 @@ from .platform import get_platform_factory
 
 
 class Font:
-    def __init__(self, family, size):
+    def __init__(self, family, size, factory=None):
         """ A :obj:`Font` is a font family (e.g. "Helvetica") and a size (e.g. 15) that can
         be applied to widgets.
 
@@ -13,7 +13,7 @@ class Font:
         self._family = family
         self._size = size
 
-        self.factory = get_platform_factory()
+        self.factory = get_platform_factory(factory)
         self._impl = self.factory.Font(interface=self)
 
     @property

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -6,6 +6,7 @@ from .widgets.box import Box
 from .widgets.button import Button
 from .command import Command
 from .widgets.canvas import Canvas
+from .font import Font
 from .widgets.icon import Icon
 from .widgets.image import *
 from .widgets.imageview import *

--- a/src/dummy/toga_dummy/font.py
+++ b/src/dummy/toga_dummy/font.py
@@ -1,0 +1,2 @@
+class Font:
+    pass

--- a/src/gtk/toga_gtk/font.py
+++ b/src/gtk/toga_gtk/font.py
@@ -12,4 +12,4 @@ class Font:
 
     def create(self):
         self._impl = Pango.FontDescription.from_string(
-            self.interface.family + " " + str(self.interface.size))
+            self.family + " " + str(self.size))

--- a/src/gtk/toga_gtk/font.py
+++ b/src/gtk/toga_gtk/font.py
@@ -12,4 +12,4 @@ class Font:
 
     def create(self):
         self._impl = Pango.FontDescription.from_string(
-            self.family + " " + str(self.size))
+            self.interface.family + " " + str(self.interface.size))


### PR DESCRIPTION
As my first contribution to the BeeWare Toga project, I was planning on writing some tests to increase coverage as suggested by the [contribution guide on Read The Docs](http://toga.readthedocs.io/en/latest/how-to/contribute.html).

 I decided that `core/toga/font.py` looked like an easy place to start (its a single class with two getters), but when I ran my tests I got some errors coming from `gtk/toga_gtk/font.py`, saying that `self.family` and `self.size` were undefined. This is because those properties are defined on the core Font class (which the GTK Font class keeps an instance of thru `self.interface`). I can see how a person might have been confused by the two similar-ish Font classes and forgot which class the properties belong to.

If this commit looks good, I plan on also writing the tests for the `core/toga/font.py`, but I am open to other needs/issues/features.