### PR TITLE
Give Window on_close method the correct arguments for GTK+

### DIFF
--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -86,7 +86,7 @@ import gbulb
 class MainWindow(Window):
     _IMPL_CLASS = Gtk.ApplicationWindow
 
-    def on_close(self, widget):
+    def on_close(self, widget, data):
         pass
 
 


### PR DESCRIPTION
Fixes #266.

Signed-off-by: Dan Yeaw <dan@yeaw.me>