### PR TITLE
Implement refresh() for GTK toga.Table

### DIFF
--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -180,8 +180,8 @@ class Table(Widget):
     @property
     def on_select(self):
         """ The callback function that is invoked when a row of the table is selected.
-        The provided callback function has to accept two arguments table (``:obj:Table`)
-        and row (``int`` or ``None``).
+        The provided callback function has to accept one argument, table
+        (``:obj:Table``), and keyword arguments (i.e. **kwargs).
 
         Returns:
             (``callable``) The callback function.

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -174,7 +174,8 @@ class Table(Widget):
 
         if data is not None:
             self._data.add_listener(self)
-            self._data._refresh()
+
+        self._impl.refresh()
 
     @property
     def on_select(self):

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -174,6 +174,7 @@ class Table(Widget):
 
         if data is not None:
             self._data.add_listener(self)
+            self._data._refresh()
 
     @property
     def on_select(self):

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -180,8 +180,8 @@ class Table(Widget):
     @property
     def on_select(self):
         """ The callback function that is invoked when a row of the table is selected.
-        The provided callback function has to accept one argument, table
-        (``:obj:Table``), and keyword arguments (i.e. **kwargs).
+        The provided callback function has to accept two arguments table (``:obj:Table`)
+        and row (``int`` or ``None``).
 
         Returns:
             (``callable``) The callback function.

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -27,6 +27,7 @@ class Button(Widget):
             # Disconnect all other on-click handlers, so that if you reassign
             # the on_press, it doesn't trigger the old ones too.
             self.native.disconnect(conn_id)
+            self._connections.remove(conn_id)
 
         self._connections.append(self.native.connect("clicked", handler))
 

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -10,9 +10,9 @@ class Table(Widget):
         self.table = Gtk.TreeView(self.data)
 
         self.columns = []
-        for heading in self.interface.headings:
+        for i, heading in enumerate(self.interface.headings):
             renderer = Gtk.CellRendererText()
-            column = Gtk.TreeViewColumn(heading, renderer, text=0)
+            column = Gtk.TreeViewColumn(heading, renderer, text=i)
             self.table.append_column(column)
 
         self.native = Gtk.ScrolledWindow()
@@ -23,7 +23,10 @@ class Table(Widget):
         self.native.interface = self.interface
 
     def refresh(self):
-        raise NotImplementedError()
+        self.data.clear()
+
+        for row in self.interface.data.rows:
+            self.data.append(row.data)
 
     def set_on_select(self, handler):
         pass

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -31,10 +31,14 @@ class Table(Widget):
             self.data.append(row.data)
 
     def set_on_select(self, handler):
+
         for conn_id in self._connections:
             # Disconnect all other on_select handlers, so that if you reassign
             # the on_select, it doesn't trigger the old ones too.
             self.table.disconnect(conn_id)
+
+        if handler is None:
+            return
 
         def _handler(widget, *args):
             selection = widget.get_selection()

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -10,6 +10,8 @@ class Table(Widget):
         # Create a table view, and put it in a scroll view.
         # The scroll view is the native, because it's the outer container.
         self.table = Gtk.TreeView(self.data)
+        self.selection = self.table.get_selection()
+        self.selection.set_mode(Gtk.SelectionMode.SINGLE)
 
         self.columns = []
         for i, heading in enumerate(self.interface.headings):
@@ -40,13 +42,14 @@ class Table(Widget):
         if handler is None:
             return
 
-        def _handler(widget, *args):
-            selection = widget.get_selection()
-            selection.set_mode(Gtk.SelectionMode.SINGLE)
+        def _handler(selection):
             tree_model, tree_iter = selection.get_selected()
-            tree_path = tree_model.get_path(tree_iter)
-            index = tree_path.get_indices()[0]
 
-            handler(widget, row=index)
+            if tree_iter:
+                tree_path = tree_model.get_path(tree_iter)
+                index = tree_path.get_indices()[0]
+                handler(widget, row=index)
+            else:
+                handler(widget, row=None)
 
-        self._connections.append(self.table.connect("cursor-changed", _handler))
+        self._connections.append(self.selection.connect("changed", _handler))

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -37,7 +37,8 @@ class Table(Widget):
         for conn_id in self._connections:
             # Disconnect all other on_select handlers, so that if you reassign
             # the on_select, it doesn't trigger the old ones too.
-            self.table.disconnect(conn_id)
+            self.selection.disconnect(conn_id)
+            self._connections.remove(conn_id)
 
         if handler is None:
             return
@@ -48,8 +49,8 @@ class Table(Widget):
             if tree_iter:
                 tree_path = tree_model.get_path(tree_iter)
                 index = tree_path.get_indices()[0]
-                handler(widget, row=index)
+                handler(self.table, row=index)
             else:
-                handler(widget, row=None)
+                handler(self.table, row=None)
 
         self._connections.append(self.selection.connect("changed", _handler))


### PR DESCRIPTION
I have a linux environment, so I plan on working with `toga_gtk`. 
These changes allow GTK Tables to render row data. 
A small change would also made to the Core API Table class; see the commit for details.