### PR TITLE
Implement GTK+ Selection `on_select` + Create example app

### DIFF
--- a/examples/selection/README.rst
+++ b/examples/selection/README.rst
@@ -1,0 +1,19 @@
+Selection example
+===============
+
+Selection example for the `Toga widget toolkit`_. The following switch features are present on this example:
+
+* Switches with a callback function when toggled
+* A disabled select box
+* Switches modified using CSS from `colosseum`_
+* A grid of switches using the flexbox from CSS of `colosseum`_
+* Different switches's background color
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    > pip install toga
+    > python -m selection
+

--- a/examples/selection/selection/__init__.py
+++ b/examples/selection/selection/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/selection/selection/__main__.py
+++ b/examples/selection/selection/__main__.py
@@ -1,0 +1,4 @@
+from selection.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -1,0 +1,72 @@
+import toga
+from colosseum import CSS
+
+
+class SelectionApp(toga.App):
+    
+    def startup(self):
+        # Main window of the application with title and size
+        self.main_window = toga.MainWindow(self.name, size=(640, 400))
+        self.main_window.app = self
+        
+        # set up common styls
+        label_style = CSS(flex=1, padding_right=24)
+        box_style = CSS(flex_direction="row", padding=24)
+        
+        # Add the content on the main window
+        self.main_window.content = toga.Box(
+            children=[
+                
+                toga.Box(style=box_style, children=[
+                    toga.Label("Select an element", 
+                        style=label_style),
+                        
+                    toga.Selection(items=["Carbon", "Ytterbium", "Thulium"])
+                ]),
+                
+                toga.Box(style=box_style, children=[
+                    toga.Label("use the 'on_select' callback to respond to changes", 
+                        style=label_style),
+                        
+                    toga.Selection(
+                      on_select=self.my_on_select,
+                      items=["Dubnium", "Holmium", "Zirconium"])
+                        
+                ]),
+                
+                toga.Box(style=box_style, children=[
+                    toga.Label("Long lists of items should scroll",
+                        style=label_style),
+                        
+                    toga.Selection(items=dir(toga)),
+                ]),
+                
+                toga.Box(style=box_style, children=[
+                    toga.Label("use some style!", style=label_style),
+                    
+                    toga.Selection(
+                        style=CSS(width=200, padding=24),
+                        items=["Curium", "Titanium", "Copernicium"])
+                ]),
+                
+                toga.Box(style=box_style, children=[
+                    toga.Label("Selection widgets can be disabled", style=label_style),
+                    
+                    toga.Selection(enabled=False)
+                ]),
+            ],
+            style=CSS(padding=24)
+        )
+
+        self.main_window.show()
+
+    def my_on_select(self, selection):
+    
+        # get the current value of the slider with `selection.value`
+    
+        print("The slection widget changed to {0}".format(selection.value))
+        
+
+def main():
+    # App name and namespace
+    return SelectionApp('Switchs', 'org.pybee.helloworld')

--- a/examples/selection/setup.py
+++ b/examples/selection/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import io
+import re
+from setuptools import setup, find_packages
+import sys
+
+with io.open('./selection/__init__.py', encoding='utf8') as version_file:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+    if version_match:
+        version = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
+with io.open('README.rst', encoding='utf8') as readme:
+    long_description = readme.read()
+
+
+setup(
+    name='selection',
+    version=version,
+    description='A demonstration of all features of a toga.Selection example for the native GUI toolkit, Toga.',
+    long_description=long_description,
+    author='BeeWare',
+    author_email='contact@pybee.org',
+    license='New BSD',
+    packages=find_packages(exclude=['docs', 'tests']),
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: User Interfaces',
+        'Topic :: Software Development :: Widget Sets',
+    ],
+    options={
+        'app': {
+            'formal_name': 'Selection',
+            'bundle': 'org.pybee'
+        },
+        'macos': {
+            'app_requires': [
+                'toga-gtk',
+            ]
+        },
+    }
+)

--- a/src/core/toga/widgets/selection.py
+++ b/src/core/toga/widgets/selection.py
@@ -16,7 +16,7 @@ class Selection(Widget):
 
     def __init__(self, id=None, style=None, items=None, on_select=None, enabled=True, factory=None):
         super().__init__(id=id, style=style, factory=factory)
-
+        self._on_select = None # needed for _impl initialization
         self._impl = self.factory.Selection(interface=self)
 
         if items is None:

--- a/src/core/toga/widgets/selection.py
+++ b/src/core/toga/widgets/selection.py
@@ -14,7 +14,7 @@ class Selection(Widget):
             implementation of this class with the same name. (optional & normally not needed)
     """
 
-    def __init__(self, id=None, style=None, items=None, on_select=None, factory=None):
+    def __init__(self, id=None, style=None, items=None, on_select=None, enabled=True, factory=None):
         super().__init__(id=id, style=style, factory=factory)
 
         self._impl = self.factory.Selection(interface=self)
@@ -27,6 +27,7 @@ class Selection(Widget):
                 self._impl.add_item(item)
 
         self.on_select = on_select
+        self.enabled = enabled
 
     @property
     def items(self):

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -22,6 +22,10 @@ class Selection(Widget):
         # self._text.append(item)
         self.native.append_text(item)
 
+        # Gtk.ComboBox does not select the first item, so it's done here.
+        if not self.get_selected_item():
+            self.select_item(item)
+
     def select_item(self, item):
         self.native.set_active(self.interface.items.index(item))
 
@@ -33,4 +37,4 @@ class Selection(Widget):
         self.interface.style.height = 32
 
     def set_on_select(self, handler):
-        self._on_select_handler = handler
+        pass

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -4,10 +4,17 @@ from .base import Widget
 
 class Selection(Widget):
     def create(self):
+        self._on_select_handler = None
+
         self.native = Gtk.ComboBoxText.new()
         self.native.interface = self.interface
+        self.native.connect("changed", self._on_select)
 
         self.rehint()
+
+    def _on_select(self, widget):
+        if self._on_select_handler:
+            self._on_select_handler(widget)
 
     def remove_all_items(self):
         # self._text.clear()
@@ -28,4 +35,4 @@ class Selection(Widget):
         self.interface.style.height = 32
 
     def set_on_select(self, handler):
-        pass
+        self._on_select_handler = handler

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -4,8 +4,6 @@ from .base import Widget
 
 class Selection(Widget):
     def create(self):
-        self._on_select_handler = None
-
         self.native = Gtk.ComboBoxText.new()
         self.native.interface = self.interface
         self.native.connect("changed", self._on_select)
@@ -13,8 +11,8 @@ class Selection(Widget):
         self.rehint()
 
     def _on_select(self, widget):
-        if self._on_select_handler:
-            self._on_select_handler(widget)
+        if self.interface.on_select:
+            self.interface.on_select(widget)
 
     def remove_all_items(self):
         # self._text.clear()


### PR DESCRIPTION
See the  example app to view `on_select` in action.
I made another change to the GTK Selection: the first item will be selected by default. I think this is fairly expected behavior; I know that HTML5 `<select>` does this, for example. Previously, the Selection widget was blank when the app opens.