### PR TITLE
Fix GTK+ Tree row selection

### DIFF
--- a/src/gtk/toga_gtk/widgets/tree.py
+++ b/src/gtk/toga_gtk/widgets/tree.py
@@ -39,12 +39,14 @@ class Tree(Widget):
         except AttributeError:
             item._impl = {self: impl}
 
-        self.nodes[impl] = item
+        path = self.store.get_path(impl)
+        self.nodes[str(path)] = item
 
     def _on_select(self, selection):
         if hasattr(self.interface, "_on_select") and self.interface.on_select:
             tree_model, impl = selection.get_selected()
-            self.interface.on_select(None, row=self.nodes.get(impl, None))
+            path = str(tree_model.get_path(impl))
+            self.interface.on_select(None, row=self.nodes.get(path, None))
 
     def change_source(self, source):
         # Temporarily disconnecting the TreeStore improves performance for large


### PR DESCRIPTION
The Issue: selected row is always None
Reason: the `Gtk.TreeIter` returned by `get_selection()` was never the same one returned by `self.store.insert()`. Therefore, a lookup with `self.nodes.get(treeiter)` always failed.

The solution I chose was to store a tree path in `self.nodes` string instead of Gtk.TreeIter so `self.nodes.get(treeiter)` finds a result.

I should note that I haven't tested `Tree.change` yet since the example app only performs `insert`.