### PR TITLE
Cleanup imports

### DIFF
--- a/contrib/build_compat_tables.py
+++ b/contrib/build_compat_tables.py
@@ -5,7 +5,7 @@
 """
 import ast
 import os
-import sys
+
 import pytablewriter
 
 """

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/demo/toga_demo/app.py
+++ b/demo/toga_demo/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+
 import toga
 from colosseum import CSS
 

--- a/docs/tutorial/source/tutorial-4.py
+++ b/docs/tutorial/source/tutorial-4.py
@@ -1,5 +1,6 @@
-import toga
 import math
+
+import toga
 
 
 class StartApp(toga.App):

--- a/examples/.template/{{ cookiecutter.name }}/setup.py
+++ b/examples/.template/{{ cookiecutter.name }}/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./{{ cookiecutter.name }}/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/beeliza/beeliza/bot.py
+++ b/examples/beeliza/beeliza/bot.py
@@ -31,9 +31,8 @@
 # SOFTWARE.
 #
 #----------------------------------------------------------------------
-import string
-import re
 import random
+import re
 
 
 class Eliza:

--- a/examples/beeliza/setup.py
+++ b/examples/beeliza/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./beeliza/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/button/setup.py
+++ b/examples/button/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./button/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/detailedlist/setup.py
+++ b/examples/detailedlist/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./detailedlist/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/selection/setup.py
+++ b/examples/selection/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./selection/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/slider/setup.py
+++ b/examples/slider/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./slider/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/switch/setup.py
+++ b/examples/switch/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./switch/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/table/setup.py
+++ b/examples/table/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./table/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -3,7 +3,6 @@ from random import choice
 import toga
 from colosseum import CSS
 
-
 headings = ['Title', 'Year', 'Rating', 'Genre']
 bee_movies = [
     ('The Secret Life of Bees', '2008', '7.3', 'Drama'),

--- a/examples/table_source/setup.py
+++ b/examples/table_source/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./table_source/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/table_source/table_source/app.py
+++ b/examples/table_source/table_source/app.py
@@ -1,9 +1,8 @@
 from random import choice
 
 import toga
-from toga.sources import Source
 from colosseum import CSS
-
+from toga.sources import Source
 
 bee_movies = [
     ('The Secret Life of Bees', '2008', '7.3', 'Drama'),

--- a/examples/tree/setup.py
+++ b/examples/tree/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./tree/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tree/tree/app.py
+++ b/examples/tree/tree/app.py
@@ -3,7 +3,6 @@ from random import choice
 import toga
 from colosseum import CSS
 
-
 bee_movies = [
     {'year': 2008, 'title': 'The Secret Life of Bees', 'rating': '7.3', 'genre': 'Drama'},
     {'year': 2007, 'title': 'Bee Movie', 'rating': '6.1', 'genre': 'Animation, Adventure, Comedy'},

--- a/examples/tree_source/setup.py
+++ b/examples/tree_source/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./tree_source/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -1,9 +1,8 @@
 from random import choice
 
 import toga
-from toga.sources import Source
 from colosseum import CSS
-
+from toga.sources import Source
 
 bee_movies = [
     {'year': 2008, 'title': 'The Secret Life of Bees', 'rating': '7.3', 'genre': 'Drama'},

--- a/examples/tutorial0/setup.py
+++ b/examples/tutorial0/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./button/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tutorial1/setup.py
+++ b/examples/tutorial1/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./button/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tutorial2/setup.py
+++ b/examples/tutorial2/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tutorial3/setup.py
+++ b/examples/tutorial3/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./button/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tutorial4/setup.py
+++ b/examples/tutorial4/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import io
 import re
+
 from setuptools import setup, find_packages
-import sys
 
 with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -1,5 +1,6 @@
-import toga
 import math
+
+import toga
 
 
 class StartApp(toga.App):

--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/android/tests/test_implementation.py
+++ b/src/android/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -1,15 +1,55 @@
-from .app import *
-from .widgets.box import *
-from .widgets.button import *
-from .widgets.label import *
-from .widgets.textinput import *
+from .app import App, MainWindow
+# from .command import Command
+# from .font import Font
+from .widgets.box import Box
+from .widgets.button import Button
+# from .widgets.canvas import Canvas
+# from .widgets.detailedlist import DetailedList
+# from .widgets.icon import Icon
+# from .widgets.image import *
+# from .widgets.imageview import *
+from .widgets.label import Label
+# from .widgets.multilinetextinput import *
+# from .widgets.numberinput import NumberInput
+# from .widgets.optioncontainer import *
+# from .widgets.passwordinput import *
+# from .widgets.progressbar import *
+# from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
+# from .widgets.slider import *
+# from .widgets.splitcontainer import *
+# from .widgets.switch import *
+# from .widgets.table import *
+from .widgets.textinput import TextInput
+# from .widgets.tree import *
+# from .widgets.webview import *
+from .window import Window
 
 __all__ = [
-    '__version__',
-    'App',
-    'Window', 'MainWindow',
+    'App', 'MainWindow',
+    # 'Command',
+    # 'Font',
     'Box',
     'Button',
+    # 'Canvas',
+    'DetailedList',
+    # 'Icon',
+    # 'Image',
+    # 'ImageView',
     'Label',
+    # 'MultilineTextInput',
+    # 'NumberInput',
+    # 'OptionContainer',
+    # 'PasswordInput',
+    # 'ProgressBar',
+    # 'ScrollContainer',
+    # 'Selection',
+    # 'Slider',
+    # 'SplitContainer',
+    # 'Switch',
+    # 'Table',
     'TextInput',
+    # 'Tree',
+    # 'WebView',
+    'Window',
 ]

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -1,47 +1,15 @@
-# Core capabilities
 from .app import *
-from .window import *
-# from .command import *
-
-# Widgets
 from .widgets.box import *
 from .widgets.button import *
-# from .widgets.icon import *
-# from .widgets.image import *
-# from .widgets.imageview import *
 from .widgets.label import *
-# from .widgets.dialog import *
-# from .widgets.multilinetextinput import *
-# from .widgets.optioncontainer import *
-# from .widgets.passwordinput import *
-# from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
-# from .widgets.splitcontainer import *
-# from .widgets.table import *
 from .widgets.textinput import *
-# from .widgets.tree import *
-# from .widgets.webview import *
 
 __all__ = [
     '__version__',
     'App',
     'Window', 'MainWindow',
-    # 'Command',
     'Box',
     'Button',
-    # 'Icon', 'TIBERIUS_ICON',
-    # 'Image',
-    # 'ImageView',
     'Label',
-    # 'Dialog',
-    # 'MultilineTextInput',
-    # 'OptionContainer',
-    # 'PasswordInput',
-    # 'ProgressBar',
-    # 'ScrollContainer',
-    # 'SplitContainer',
-    # 'Table',
     'TextInput',
-    # 'Tree',
-    # 'WebView',
 ]

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -2,8 +2,6 @@ from android.view import Gravity
 
 from toga.constants import *
 
-from .base import WidgetMixin
-
 
 class TogaLabel(extends=android.widget.TextView):
     @super({context: android.content.Context})

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,7 +1,3 @@
-from .container import Container
-from . import dialogs
-
-
 class Window:
     def __init__(self, interface):
         self.interface = interface

--- a/src/cocoa/setup.py
+++ b/src/cocoa/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/cocoa/tests/test_implementation.py
+++ b/src/cocoa/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -2,12 +2,11 @@ import asyncio
 import os
 import sys
 
-from rubicon.objc.eventloop import EventLoopPolicy, CocoaLifecycle
 import toga
+from rubicon.objc.eventloop import EventLoopPolicy, CocoaLifecycle
 
 from .libs import *
 from .window import Window
-# from .widgets.icon import Icon
 
 
 class MainWindow(Window):

--- a/src/cocoa/toga_cocoa/container.py
+++ b/src/cocoa/toga_cocoa/container.py
@@ -2,10 +2,7 @@ from .libs import (
     objc_method,
     NSLayoutAttributeTop, NSLayoutAttributeLeft,
     NSLayoutAttributeRight, NSLayoutAttributeBottom,
-    NSLayoutRelationEqual, NSLayoutRelationGreaterThanOrEqual, NSLayoutRelationLessThanOrEqual,
-    NSLayoutConstraint,
-    NSLayoutPriority,
-    NSRect, NSPoint, NSSize,
+    NSLayoutRelationEqual, NSLayoutConstraint,
     NSView
 )
 

--- a/src/cocoa/toga_cocoa/factory.py
+++ b/src/cocoa/toga_cocoa/factory.py
@@ -1,9 +1,6 @@
 from .app import App, MainWindow
 from .command import Command
-from .window import Window
 from .font import Font
-
-# Widgets
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.detailedlist import DetailedList
@@ -12,10 +9,12 @@ from .widgets.image import *
 from .widgets.imageview import *
 from .widgets.label import Label
 from .widgets.multilinetextinput import *
+from .widgets.numberinput import NumberInput
 from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
+from .widgets.selection import Selection
 from .widgets.slider import *
 from .widgets.splitcontainer import *
 from .widgets.switch import *
@@ -23,17 +22,13 @@ from .widgets.table import *
 from .widgets.textinput import TextInput
 from .widgets.tree import *
 from .widgets.webview import *
-from .widgets.selection import Selection
-from .widgets.numberinput import NumberInput
+from .window import Window
 
 __all__ = [
     'App', 'MainWindow',
     'Command',
-
     'Window',
-
     'Font',
-
     'Box',
     'Button',
     'DetailedList',

--- a/src/cocoa/toga_cocoa/factory.py
+++ b/src/cocoa/toga_cocoa/factory.py
@@ -3,6 +3,7 @@ from .command import Command
 from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
+# from .widgets.canvas import Canvas
 from .widgets.detailedlist import DetailedList
 from .widgets.icon import Icon
 from .widgets.image import *
@@ -27,10 +28,10 @@ from .window import Window
 __all__ = [
     'App', 'MainWindow',
     'Command',
-    'Window',
     'Font',
     'Box',
     'Button',
+    # 'Canvas',
     'DetailedList',
     'Icon',
     'Image',
@@ -50,4 +51,5 @@ __all__ = [
     'TextInput',
     'Tree',
     'WebView',
+    'Window',
 ]

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -6,7 +6,6 @@ from ctypes import util
 from enum import Enum
 
 from rubicon.objc import *
-
 from toga.constants import *
 from toga.constants.color import *
 

--- a/src/cocoa/toga_cocoa/libs/core_graphics.py
+++ b/src/cocoa/toga_cocoa/libs/core_graphics.py
@@ -3,11 +3,8 @@
 ##########################################################################
 from ctypes import *
 from ctypes import util
-from enum import Enum
 
-from rubicon.objc import *
 from rubicon.objc.types import register_preferred_encoding
-
 from toga.constants import *
 from toga.constants.color import *
 

--- a/src/cocoa/toga_cocoa/widgets/box.py
+++ b/src/cocoa/toga_cocoa/widgets/box.py
@@ -1,5 +1,3 @@
-from rubicon.objc import *
-
 from .base import Widget
 
 

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -1,9 +1,7 @@
 from rubicon.objc import objc_method, SEL
-
 from toga_cocoa.libs import *
 
 from .base import Widget
-
 
 
 class TogaButton(NSButton):

--- a/src/cocoa/toga_cocoa/widgets/detailedlist.py
+++ b/src/cocoa/toga_cocoa/widgets/detailedlist.py
@@ -1,5 +1,4 @@
 from rubicon.objc import *
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/label.py
+++ b/src/cocoa/toga_cocoa/widgets/label.py
@@ -1,5 +1,3 @@
-from toga.constants import LEFT_ALIGNED
-
 from toga_cocoa.libs import NSTextField, NSTextAlignment
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/numberinput.py
+++ b/src/cocoa/toga_cocoa/widgets/numberinput.py
@@ -1,13 +1,10 @@
-from rubicon.objc import objc_method, SEL
-
 import toga
+from rubicon.objc import objc_method, SEL
 from toga.widgets.base import Widget as InterfaceWidget
+from toga_cocoa.libs import NSStepper, NSObject
 
-from toga_cocoa.libs import NSStepper, NSView, NSMakeRect, NSObject
-
-from .box import Box
 from .base import Widget
-
+from .box import Box
 
 
 class NumberInput(Box):

--- a/src/cocoa/toga_cocoa/widgets/progressbar.py
+++ b/src/cocoa/toga_cocoa/widgets/progressbar.py
@@ -1,4 +1,5 @@
 from toga_cocoa.libs import *
+
 from .base import Widget
 
 

--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method, SEL
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/splitcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/splitcontainer.py
@@ -1,5 +1,6 @@
 from toga_cocoa.container import Container
 from toga_cocoa.libs import *
+
 from .base import Widget
 
 

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method, SEL
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -1,5 +1,4 @@
 from toga.sources import to_accessor
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -1,7 +1,5 @@
 from rubicon.objc import *
-
 from toga.sources import to_accessor
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method
-
 from toga_cocoa.libs import *
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -1,7 +1,8 @@
+from toga.command import Command as BaseCommand
+
+from . import dialogs
 from .container import Container
 from .libs import *
-from . import dialogs
-from toga.command import Command as BaseCommand, GROUP_BREAK, SECTION_BREAK
 
 
 def toolbar_identifier(cmd):

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/core/tests/sources/test_value_source.py
+++ b/src/core/tests/sources/test_value_source.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-import toga
 from toga.sources.value_source import ValueSource
 
 

--- a/src/core/tests/test_command.py
+++ b/src/core/tests/test_command.py
@@ -2,7 +2,6 @@ import unittest
 
 import toga
 import toga_dummy
-from toga_dummy.utils import EventLog
 
 
 class TestCommand(unittest.TestCase):

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -1,9 +1,5 @@
 import unittest
 
-import toga
-import toga_dummy
-from toga_dummy.utils import EventLog
-
 
 class TestWindow(unittest.TestCase):
     pass

--- a/src/core/tests/utils/test_handler.py
+++ b/src/core/tests/utils/test_handler.py
@@ -1,7 +1,4 @@
 import unittest
-from unittest.mock import Mock, MagicMock, patch
-import toga
-import toga_dummy
 
 
 class HandlerTests(unittest.TestCase):

--- a/src/core/tests/widgets/test_base.py
+++ b/src/core/tests/widgets/test_base.py
@@ -1,9 +1,8 @@
 import unittest
 
-from colosseum import CSS
-
 import toga
 import toga_dummy
+from colosseum import CSS
 from toga_dummy.utils import TestCase
 
 

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -1,7 +1,8 @@
+import math
+
 import toga
 import toga_dummy
-from toga_dummy.utils import EventLog, TestCase
-import math
+from toga_dummy.utils import TestCase
 
 
 class CanvasTests(TestCase):

--- a/src/core/tests/widgets/test_icon.py
+++ b/src/core/tests/widgets/test_icon.py
@@ -2,7 +2,6 @@ import unittest
 
 import toga
 import toga_dummy
-from toga_dummy.utils import EventLog
 
 
 class TestIcon(unittest.TestCase):

--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -1,8 +1,6 @@
 import toga
-
-from toga.sources import ListSource, Source
-
 import toga_dummy
+from toga.sources import ListSource, Source
 from toga_dummy.utils import TestCase
 
 

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -1,37 +1,30 @@
 from .app import *
 from .command import *
-from .window import Window
 from .constants import *
-
-# Font support
 from .font import Font
-
-# Widgets
 from .widgets.base import Layout, Point, Widget
-
 from .widgets.box import Box
 from .widgets.button import Button
-from .widgets.detailedlist import DetailedList
 from .widgets.canvas import Canvas
-# from .widgets.icon import Icon
+from .widgets.detailedlist import DetailedList
 from .widgets.image import *
 from .widgets.imageview import *
 from .widgets.label import Label
 from .widgets.multilinetextinput import *
+from .widgets.numberinput import NumberInput
 from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
+from .widgets.selection import Selection
 from .widgets.slider import *
 from .widgets.splitcontainer import *
 from .widgets.switch import *
 from .widgets.table import *
 from .widgets.textinput import TextInput
-
 from .widgets.tree import *
 from .widgets.webview import *
-from .widgets.selection import Selection
-from .widgets.numberinput import NumberInput
+from .window import Window
 
 __all__ = [
     # Applications

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -3,10 +3,10 @@ import signal
 import sys
 from builtins import id as identifier
 
-from toga.platform import get_platform_factory
-from toga.window import Window
 from toga.command import CommandSet
+from toga.platform import get_platform_factory
 from toga.widgets.icon import Icon
+from toga.window import Window
 
 
 class MainWindow(Window):

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -1,6 +1,6 @@
+import toga_dummy
 from toga.handlers import wrapped_handler
 from toga.platform import get_platform_factory
-import toga_dummy
 
 
 class Group:

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -1,6 +1,6 @@
 from builtins import id as identifier
-from colosseum import CSS
 
+from colosseum import CSS
 from toga.platform import get_platform_factory
 
 

--- a/src/core/toga/widgets/detailedlist.py
+++ b/src/core/toga/widgets/detailedlist.py
@@ -1,5 +1,5 @@
 from toga.handlers import wrapped_handler
-from toga.sources import to_accessor, ListSource
+from toga.sources import ListSource
 
 from .base import Widget
 

--- a/src/core/toga/widgets/image.py
+++ b/src/core/toga/widgets/image.py
@@ -1,7 +1,5 @@
 from toga.platform import get_platform_factory
 
-from .base import Widget
-
 
 class Image(object):
     """

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -3,7 +3,6 @@ from toga.sources import ListSource
 from toga.sources.accessors import build_accessors
 
 from .base import Widget
-from .icon import Icon
 
 
 class Table(Widget):

--- a/src/core/toga/widgets/tree.py
+++ b/src/core/toga/widgets/tree.py
@@ -3,7 +3,6 @@ from toga.sources import TreeSource
 from toga.sources.accessors import build_accessors
 
 from .base import Widget
-from .icon import Icon
 
 
 class Tree(Widget):

--- a/src/curses/setup.py
+++ b/src/curses/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/curses/tests/test_implementation.py
+++ b/src/curses/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/django/setup.py
+++ b/src/django/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/django/tests/test_implementation.py
+++ b/src/django/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/django/toga_django/__init__.py
+++ b/src/django/toga_django/__init__.py
@@ -1,23 +1,61 @@
 from . import django
-from .app import *
+from .app import App, MainWindow
+# from .command import Command
+# from .font import Font
 from .widgets.box import *
 from .widgets.button import *
+# from .widgets.canvas import Canvas
+# from .widgets.detailedlist import DetailedList
+# from .widgets.icon import *
+# from .widgets.image import *
+# from .widgets.imageview import *
 from .widgets.label import *
+# from .widgets.multilinetextinput import *
+# from .widgets.numberinput import NumberInput
+# from .widgets.optioncontainer import *
+# from .widgets.passwordinput import *
+# from .widgets.progressbar import *
+# from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
+# from .widgets.slider import *
+# from .widgets.splitcontainer import *
+# from .widgets.switch import *
+# from .widgets.table import *
 from .widgets.textinput import *
+# from .widgets.tree import *
 from .widgets.webview import *
-from .window import *
+from .window import Window
 
 
 __all__ = [
     '__version__',
     'django',
-    'App',
-    'Window', 'MainWindow',
+    'App', 'MainWindow',
+    # 'Command',
+    # 'Font',
     'Box',
     'Button',
+    # 'Canvas',
+    # 'DetailedList',
+    # 'Icon',
+    # 'Image',
+    # 'ImageView',
     'Label',
+    # 'MultilineTextInput',
+    # 'NumberInput',
+    # 'OptionContainer',
+    # 'PasswordInput',
+    # 'ProgressBar',
+    # 'ScrollContainer',
+    # 'Selection',
+    # 'Slider',
+    # 'SplitContainer',
+    # 'Switch',
+    # 'Table',
     'TextInput',
+    # 'Tree',
     'WebView',
+    'Window',
 ]
 
 # Examples of valid version strings

--- a/src/django/toga_django/__init__.py
+++ b/src/django/toga_django/__init__.py
@@ -1,54 +1,22 @@
-# Django app definition
 from . import django
-
-# Core capabilities
 from .app import *
-from .window import *
-# from .command import *
-
-# Widgets
 from .widgets.box import *
 from .widgets.button import *
-# from .widgets.icon import *
-# from .widgets.image import *
-# from .widgets.imageview import *
 from .widgets.label import *
-# from .widgets.list import *
-# from .widgets.dialog import *
-# from .widgets.multilinetextinput import *
-# from .widgets.optioncontainer import *
-# from .widgets.passwordinput import *
-# from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
-# from .widgets.splitcontainer import *
-# from .widgets.table import *
 from .widgets.textinput import *
-# from .widgets.tree import *
 from .widgets.webview import *
+from .window import *
+
 
 __all__ = [
     '__version__',
     'django',
     'App',
     'Window', 'MainWindow',
-#     'Command', 'SEPARATOR', 'SPACER', 'EXPANDING_SPACER',
     'Box',
     'Button',
-#     'Icon', 'TIBERIUS_ICON',
-#     'Image',
-#     'ImageView',
     'Label',
-    # 'List', 'SimpleListElement',
-#     'Dialog',
-#     'MultilineTextInput',
-#     'OptionContainer',
-#     'PasswordInput',
-#     'ProgressBar',
-#     'ScrollContainer',
-#     'SplitContainer',
-#     'Table',
     'TextInput',
-#     'Tree',
     'WebView',
 ]
 

--- a/src/django/toga_django/app.py
+++ b/src/django/toga_django/app.py
@@ -1,4 +1,3 @@
-# import types
 import base64
 import marshal
 import os
@@ -8,13 +7,11 @@ import tempfile
 from django.conf.urls import url
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
-
 from toga.interface.app import App as AppInterface
 from toga.interface.widgets.base import Widget
 
-from .window import Window
 from .bootstrap import bootstrap
-from . import impl
+from .window import Window
 
 
 class MainWindow(Window):

--- a/src/django/toga_django/impl/__init__.py
+++ b/src/django/toga_django/impl/__init__.py
@@ -9,10 +9,10 @@ from .app import App
 from .box import Box
 from .button import Button
 from .label import Label
-# from .list import List, SimpleListElement
 from .textinput import TextInput
-from .window import Window
 from .webview import WebView
+from .window import Window
+
 
 # _counter = 1000
 

--- a/src/django/toga_django/widgets/box.py
+++ b/src/django/toga_django/widgets/box.py
@@ -1,5 +1,5 @@
-from .. import impl
 from .base import Widget
+from .. import impl
 
 
 class Box(Widget):

--- a/src/django/toga_django/widgets/button.py
+++ b/src/django/toga_django/widgets/button.py
@@ -1,5 +1,4 @@
 from .. import impl
-from .base import WidgetMixin
 
 
 class Button(Widget):

--- a/src/django/toga_django/widgets/label.py
+++ b/src/django/toga_django/widgets/label.py
@@ -1,5 +1,5 @@
-from .. import impl
 from .base import Widget
+from .. import impl
 
 
 class Label(Widget):

--- a/src/django/toga_django/widgets/textinput.py
+++ b/src/django/toga_django/widgets/textinput.py
@@ -1,8 +1,7 @@
 from toga.interface import TextInput as TextInputInterface
 
-from .. import impl
 from .base import WidgetMixin
-# from ..libs import TextInput as TogaTextInput
+from .. import impl
 
 
 class TextInput(TextInputInterface, WidgetMixin):

--- a/src/django/toga_django/widgets/webview.py
+++ b/src/django/toga_django/widgets/webview.py
@@ -1,8 +1,7 @@
 from toga.interface import WebView as WebViewInterface
 
-from .. import impl
 from .base import WidgetMixin
-# from ..libs import WebView as TogaWebView
+from .. import impl
 
 
 class WebView(WebViewInterface, WidgetMixin):

--- a/src/django/toga_django/window.py
+++ b/src/django/toga_django/window.py
@@ -1,15 +1,14 @@
-from toga.interface.window import Window as WindowInterface
-
 import base64
 import marshal
 import os
 import py_compile
-from django.conf.urls import url
+
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
+from toga.interface.window import Window as WindowInterface
 
-from . import impl
 from . import dialogs
+from . import impl
 from .bootstrap import bootstrap
 from .container import Container
 

--- a/src/dummy/setup.py
+++ b/src/dummy/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -12,6 +12,7 @@ from .widgets.label import Label
 from .widgets.multilinetextinput import *
 from .widgets.navigationview import *
 from .widgets.numberinput import *
+from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
@@ -19,6 +20,7 @@ from .widgets.selection import Selection
 from .widgets.slider import *
 from .widgets.splitcontainer import *
 from .widgets.switch import *
+from .widgets.table import *
 from .widgets.textinput import TextInput
 from .widgets.tree import *
 from .widgets.webview import *

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -1,13 +1,10 @@
 from .app import App, MainWindow
-from .window import Window
-
-# Widgets
+from .command import Command
+from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
-from .command import Command
 from .widgets.canvas import Canvas
 from .widgets.detailedlist import DetailedList
-from .font import Font
 from .widgets.icon import Icon
 from .widgets.image import *
 from .widgets.imageview import *
@@ -18,15 +15,14 @@ from .widgets.numberinput import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
 from .widgets.scrollcontainer import *
+from .widgets.selection import Selection
 from .widgets.slider import *
 from .widgets.splitcontainer import *
 from .widgets.switch import *
-from .widgets.optioncontainer import *
-from .widgets.table import *
 from .widgets.textinput import TextInput
 from .widgets.tree import *
 from .widgets.webview import *
-from .widgets.selection import Selection
+from .window import Window
 
 __all__ = [
     'App', 'MainWindow',

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -29,12 +29,11 @@ from .window import Window
 __all__ = [
     'App', 'MainWindow',
     'Command',
-    'DetailedList',
-    'Window',
     'Font',
     'Box',
     'Button',
     'Canvas',
+    'DetailedList',
     'Icon',
     'Image',
     'ImageView',
@@ -42,6 +41,7 @@ __all__ = [
     'MultilineTextInput',
     'NavigationView',
     'NumberInput',
+    'OptionContainer'
     'PasswordInput',
     'ProgressBar',
     'ScrollContainer',
@@ -49,9 +49,9 @@ __all__ = [
     'Slider',
     'SplitContainer',
     'Switch',
-    'OptionContainer'
     'Table',
     'TextInput',
     'Tree',
     'WebView',
+    'Window',
 ]

--- a/src/dummy/toga_dummy/test_implementation.py
+++ b/src/dummy/toga_dummy/test_implementation.py
@@ -1,5 +1,5 @@
-import os
 import ast
+import os
 import unittest
 from collections import namedtuple, defaultdict
 from itertools import zip_longest

--- a/src/dummy/toga_dummy/widgets/base.py
+++ b/src/dummy/toga_dummy/widgets/base.py
@@ -1,4 +1,4 @@
-from ..utils import not_required, not_required_on, LogEntry, LoggedObject
+from ..utils import not_required_on, LoggedObject
 
 
 class Widget(LoggedObject):

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -1,4 +1,5 @@
 import re
+
 from .base import Widget
 
 

--- a/src/flask/setup.py
+++ b/src/flask/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/flask/tests/test_implementation.py
+++ b/src/flask/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/gtk/setup.py
+++ b/src/gtk/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/gtk/tests/test_implementation.py
+++ b/src/gtk/tests/test_implementation.py
@@ -1,6 +1,6 @@
 import os
-from toga_dummy import test_implementation
 
+from toga_dummy import test_implementation
 
 globals().update(
     test_implementation.create_impl_tests(

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -84,8 +84,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gio, GLib
 
 
-from toga.command import GROUP_BREAK, SECTION_BREAK, Command, Group
-# from .command import Command, Group
+from toga.command import GROUP_BREAK, SECTION_BREAK, Command
 import toga
 from .window import Window
 from toga import Icon

--- a/src/gtk/toga_gtk/command.py
+++ b/src/gtk/toga_gtk/command.py
@@ -1,5 +1,3 @@
-from toga.command import Group, Command as BaseCommand
-
 from toga import Icon
 
 

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -5,6 +5,8 @@ from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
 from .widgets.icon import Icon
+# from .widgets.image import *
+# from .widgets.imageview import *
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.numberinput import NumberInput
@@ -25,14 +27,13 @@ from .window import Window
 __all__ = [
     'App', 'MainWindow',
     'Command',
-    'Window',
     'Font',
     'Box',
     'Button',
     'Canvas',
     'Icon',
-    'Image',
-    'ImageView',
+    # 'Image',
+    # 'ImageView',
     'Label',
     'MultilineTextInput',
     'NumberInput',
@@ -48,4 +49,5 @@ __all__ = [
     'TextInput',
     'Tree',
     'WebView',
+    'Window',
 ]

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -1,21 +1,18 @@
 from .app import App, MainWindow
-from .window import Window
+from .command import Command
 from .font import Font
-
-# Widgets
 from .widgets.box import Box
 from .widgets.button import Button
-from .command import Command
 from .widgets.canvas import Canvas
 from .widgets.icon import Icon
-# from .widgets.image import *
-# from .widgets.imageview import *
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
+from .widgets.numberinput import NumberInput
 from .widgets.optioncontainer import OptionContainer
 from .widgets.passwordinput import PasswordInput
 from .widgets.progressbar import ProgressBar
 from .widgets.scrollcontainer import ScrollContainer
+from .widgets.selection import Selection
 from .widgets.slider import *
 from .widgets.splitcontainer import SplitContainer
 from .widgets.switch import Switch
@@ -23,8 +20,7 @@ from .widgets.table import Table
 from .widgets.textinput import TextInput
 from .widgets.tree import Tree
 from .widgets.webview import WebView
-from .widgets.selection import Selection
-from .widgets.numberinput import NumberInput
+from .window import Window
 
 __all__ = [
     'App', 'MainWindow',

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -1,6 +1,3 @@
-from gi.repository import Gtk
-
-
 def wrapped_handler(widget, handler):
     def _handler(impl, data=None):
         if handler:

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -1,5 +1,6 @@
-from gi.repository import Gtk
 import re
+
+from gi.repository import Gtk
 
 try:
     import cairo

--- a/src/gtk/toga_gtk/widgets/label.py
+++ b/src/gtk/toga_gtk/widgets/label.py
@@ -1,7 +1,5 @@
 from gi.repository import Gtk
-
 from toga.constants import *
-
 from toga_gtk.libs import gtk_alignment
 
 from .base import Widget

--- a/src/gtk/toga_gtk/widgets/multilinetextinput.py
+++ b/src/gtk/toga_gtk/widgets/multilinetextinput.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk
 
 from .base import Widget
 

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -1,5 +1,4 @@
 from gi.repository import Gtk
-
 from toga_gtk.container import Container
 
 from .base import Widget

--- a/src/gtk/toga_gtk/widgets/scrollcontainer.py
+++ b/src/gtk/toga_gtk/widgets/scrollcontainer.py
@@ -1,5 +1,4 @@
 from gi.repository import Gtk
-
 from toga_gtk.container import Container
 
 from .base import Widget

--- a/src/gtk/toga_gtk/widgets/splitcontainer.py
+++ b/src/gtk/toga_gtk/widgets/splitcontainer.py
@@ -1,5 +1,4 @@
 from gi.repository import Gtk
-
 from toga_gtk.container import Container
 
 from .base import Widget

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -1,10 +1,9 @@
 from gi.repository import Gtk
-
 from toga.command import GROUP_BREAK, SECTION_BREAK
 from toga.handlers import wrapped_handler
 
-from .container import Container
 from . import dialogs
+from .container import Container
 
 
 class Window:

--- a/src/iOS/setup.py
+++ b/src/iOS/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/iOS/tests/test_implementation.py
+++ b/src/iOS/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from rubicon.objc import objc_method
 from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
 
 from .libs import *

--- a/src/iOS/toga_iOS/container.py
+++ b/src/iOS/toga_iOS/container.py
@@ -3,9 +3,7 @@ from rubicon.objc import objc_method
 from .libs import (
     NSLayoutAttributeTop, NSLayoutAttributeLeft,
     NSLayoutAttributeRight, NSLayoutAttributeBottom,
-    NSLayoutRelationEqual, NSLayoutRelationGreaterThanOrEqual, NSLayoutRelationLessThanOrEqual,
-    NSLayoutConstraint,
-    NSLayoutPriority,
+    NSLayoutRelationEqual, NSLayoutConstraint,
     UIView, UIColor
 )
 

--- a/src/iOS/toga_iOS/dialogs.py
+++ b/src/iOS/toga_iOS/dialogs.py
@@ -1,5 +1,3 @@
-from rubicon.objc import *
-
 from .libs import *
 
 

--- a/src/iOS/toga_iOS/factory.py
+++ b/src/iOS/toga_iOS/factory.py
@@ -1,39 +1,19 @@
-import os
-
 from .app import App, MainWindow
-from .window import Window
-from .font import Font
-
-# Widgets
 from .widgets.box import Box
 from .widgets.button import Button
-# from .command import Command
-from .widgets.detailedlist import DetailedList
-from .widgets.label import Label
-from .widgets.icon import Icon
 from .widgets.image import *
 from .widgets.imageview import *
-
-# from .widgets.multilinetextinput import *
-# from .widgets.optioncontainer import *
+from .widgets.label import Label
 from .widgets.passwordinput import *
-# from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
 from .widgets.slider import *
-# from .widgets.splitcontainer import *
 from .widgets.switch import *
-# from .widgets.table import *
 from .widgets.textinput import TextInput
-# from .widgets.tree import *
 from .widgets.webview import *
-# from .widgets.selection import Selection
-# from .widgets.numberinput import NumberInput
+from .window import Window
 
 __all__ = [
     'App', 'MainWindow',
-    # 'Command',
     'Window',
-    # 'Font',
     'Box',
     'Button',
     'DetailedList'
@@ -41,18 +21,9 @@ __all__ = [
     'Image',
     'ImageView',
     'Label',
-    # 'MultilineTextInput',
-    # 'NumberInput',
-    # 'OptionContainer',
     'PasswordInput',
-    # 'ProgressBar',
-    # 'ScrollContainer',
-    # 'Selection',
     'Slider',
-    # 'SplitContainer',
     'Switch',
-    # 'Table',
     'TextInput',
-    # 'Tree',
     'WebView',
 ]

--- a/src/iOS/toga_iOS/factory.py
+++ b/src/iOS/toga_iOS/factory.py
@@ -1,29 +1,55 @@
 from .app import App, MainWindow
+# from .command import Command
+from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
+# from .widgets.canvas import Canvas
+from .widgets.detailedlist import DetailedList
+from .widgets.icon import Icon
 from .widgets.image import *
 from .widgets.imageview import *
 from .widgets.label import Label
+# from .widgets.multilinetextinput import *
+# from .widgets.numberinput import NumberInput
+# from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
+# from .widgets.progressbar import *
+# from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
 from .widgets.slider import *
+# from .widgets.splitcontainer import *
 from .widgets.switch import *
+# from .widgets.table import *
 from .widgets.textinput import TextInput
+# from .widgets.tree import *
 from .widgets.webview import *
 from .window import Window
 
 __all__ = [
     'App', 'MainWindow',
-    'Window',
+    # 'Command',
+    # 'Font',
     'Box',
     'Button',
-    'DetailedList'
+    # 'Canvas',
+    'DetailedList',
     'Icon',
     'Image',
     'ImageView',
     'Label',
+    # 'MultilineTextInput',
+    # 'NumberInput',
+    # 'OptionContainer',
     'PasswordInput',
+    # 'ProgressBar',
+    # 'ScrollContainer',
+    # 'Selection',
     'Slider',
+    # 'SplitContainer',
     'Switch',
+    # 'Table',
     'TextInput',
+    # 'Tree',
     'WebView',
+    'Window',
 ]

--- a/src/iOS/toga_iOS/libs/uikit.py
+++ b/src/iOS/toga_iOS/libs/uikit.py
@@ -6,7 +6,6 @@ from ctypes import util
 from enum import Enum
 
 from rubicon.objc import *
-
 from toga.constants import *
 
 ######################################################################

--- a/src/iOS/toga_iOS/widgets/box.py
+++ b/src/iOS/toga_iOS/widgets/box.py
@@ -1,5 +1,3 @@
-from rubicon.objc import *
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/button.py
+++ b/src/iOS/toga_iOS/widgets/button.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/detailedlist.py
+++ b/src/iOS/toga_iOS/widgets/detailedlist.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/imageview.py
+++ b/src/iOS/toga_iOS/widgets/imageview.py
@@ -1,5 +1,4 @@
 from toga.constants import *
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/label.py
+++ b/src/iOS/toga_iOS/widgets/label.py
@@ -1,7 +1,4 @@
 from rubicon.objc import CGSize
-
-from toga.constants import LEFT_ALIGNED
-
 from toga_iOS.libs import UILabel, NSTextAlignment, NSLineBreakByWordWrapping, CGSize
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/navigationview.py
+++ b/src/iOS/toga_iOS/widgets/navigationview.py
@@ -1,7 +1,5 @@
 from rubicon.objc import *
-
 from toga.interface import NavigationView as NavigationViewInterface
-
 from toga_iOS.libs import *
 
 from .base import WidgetMixin

--- a/src/iOS/toga_iOS/widgets/slider.py
+++ b/src/iOS/toga_iOS/widgets/slider.py
@@ -1,7 +1,7 @@
 from rubicon.objc import objc_method, SEL
+from toga_iOS.libs import UISlider, CGSize, UIControlEventValueChanged
 
 from .base import Widget
-from toga_iOS.libs import UISlider, CGSize, UIControlEventValueChanged
 
 
 class TogaSlider(UISlider):

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method, CGSize
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/textinput.py
+++ b/src/iOS/toga_iOS/widgets/textinput.py
@@ -1,5 +1,4 @@
 from rubicon.objc import CGSize
-
 from toga_iOS.libs import UITextField, UITextBorderStyleRoundedRect
 
 from .base import Widget

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -1,5 +1,4 @@
 from rubicon.objc import objc_method
-
 from toga_iOS.libs import *
 
 from .base import Widget

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -1,6 +1,5 @@
 from .container import Container
 from .libs import *
-from . import dialogs
 
 
 class Window:

--- a/src/pyramid/setup.py
+++ b/src/pyramid/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/pyramid/tests/test_implementation.py
+++ b/src/pyramid/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/qt/setup.py
+++ b/src/qt/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/qt/tests/test_implementation.py
+++ b/src/qt/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/tvOS/setup.py
+++ b/src/tvOS/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/tvOS/tests/test_implementation.py
+++ b/src/tvOS/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/uwp/setup.py
+++ b/src/uwp/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/uwp/tests/test_implementation.py
+++ b/src/uwp/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/watchOS/setup.py
+++ b/src/watchOS/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/watchOS/tests/test_implementation.py
+++ b/src/watchOS/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/web/setup.py
+++ b/src/web/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/web/tests/test_implementation.py
+++ b/src/web/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/web/toga_web/__init__.py
+++ b/src/web/toga_web/__init__.py
@@ -1,28 +1,57 @@
-# Core capabilities
-# from .app import *
-# from .window import *
-# from .command import *
-
-# Widgets
-# from .widgets.button import *
-# from .widgets.container import *
-# from .widgets.icon import *
-# from .widgets.label import *
-# from .widgets.dialog import *
+# from .app import App, MainWindow
+# from .command import Command
+# from .font import Font
+# from .widgets.box import Box
+# from .widgets.button import Button
+# from .widgets.canvas import Canvas
+# from .widgets.detailedlist import DetailedList
+# from .widgets.icon import Icon
+# from .widgets.image import *
+# from .widgets.imageview import *
+# from .widgets.label import Label
 # from .widgets.multilinetextinput import *
+# from .widgets.numberinput import NumberInput
 # from .widgets.optioncontainer import *
 # from .widgets.passwordinput import *
 # from .widgets.progressbar import *
 # from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
+# from .widgets.slider import *
 # from .widgets.splitcontainer import *
+# from .widgets.switch import *
 # from .widgets.table import *
-# from .widgets.textinput import *
+# from .widgets.textinput import TextInput
 # from .widgets.tree import *
 # from .widgets.webview import *
-
+# from .window import Window
+#
 __all__ = [
-    '__version__',
-
+    # 'App', 'MainWindow',
+    # 'Command',
+    # 'Font',
+    # 'Box',
+    # 'Button',
+    # 'Canvas',
+    # 'DetailedList',
+    # 'Icon',
+    # 'Image',
+    # 'ImageView',
+    # 'Label',
+    # 'MultilineTextInput',
+    # 'NumberInput',
+    # 'OptionContainer',
+    # 'PasswordInput',
+    # 'ProgressBar',
+    # 'ScrollContainer',
+    # 'Selection',
+    # 'Slider',
+    # 'SplitContainer',
+    # 'Switch',
+    # 'Table',
+    # 'TextInput',
+    # 'Tree',
+    # 'WebView',
+    # 'Window',
 ]
 
 # Examples of valid version strings

--- a/src/win32/setup.py
+++ b/src/win32/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/win32/tests/test_implementation.py
+++ b/src/win32/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/win32/toga_win32/__init__.py
+++ b/src/win32/toga_win32/__init__.py
@@ -1,47 +1,24 @@
-# Core capabilities
 from .app import *
-from .window import *
-# from .command import *
-
-# Widgets
 from .widgets.button import *
 from .widgets.container import *
-# from .widgets.icon import *
 from .widgets.label import *
-# from .widgets.dialog import *
 from .widgets.multilinetextinput import *
 from .widgets.numberinput import *
-# from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
-# from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
-# from .widgets.splitcontainer import *
-# from .widgets.table import *
 from .widgets.textinput import *
-# from .widgets.tree import *
-# from .widgets.webview import *
+from .window import *
 
 __all__ = [
     '__version__',
     'App',
     'Window',
-    # 'Command', 'SEPARATOR', 'SPACER', 'EXPANDING_SPACER',
     'Button',
     'Container',
-    # 'Icon', 'TIBERIUS_ICON',
     'Label',
-    # 'Dialog',
     'MultilineTextInput',
     'NumberInput',
-    # 'OptionContainer',
     'PasswordInput',
-    # 'ProgressBar',
-    # 'ScrollContainer',
-    # 'SplitContainer',
-    # 'Table',
     'TextInput',
-    # 'Tree',
-    # 'WebView',
 ]
 
 # Examples of valid version strings

--- a/src/win32/toga_win32/__init__.py
+++ b/src/win32/toga_win32/__init__.py
@@ -1,24 +1,57 @@
-from .app import *
-from .widgets.button import *
-from .widgets.container import *
-from .widgets.label import *
+from .app import App, MainWindow
+# from .command import Command
+# from .font import Font
+from .widgets.box import Box
+from .widgets.button import Button
+# from .widgets.canvas import Canvas
+# from .widgets.detailedlist import DetailedList
+# from .widgets.icon import Icon
+# from .widgets.image import *
+# from .widgets.imageview import *
+from .widgets.label import Label
 from .widgets.multilinetextinput import *
-from .widgets.numberinput import *
+from .widgets.numberinput import NumberInput
+# from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
-from .widgets.textinput import *
-from .window import *
+# from .widgets.progressbar import *
+# from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
+# from .widgets.slider import *
+# from .widgets.splitcontainer import *
+# from .widgets.switch import *
+# from .widgets.table import *
+from .widgets.textinput import TextInput
+# from .widgets.tree import *
+# from .widgets.webview import *
+from .window import Window
 
 __all__ = [
-    '__version__',
-    'App',
-    'Window',
+    'App', 'MainWindow',
+    # 'Command',
+    # 'Font',
+    # 'Box',
     'Button',
-    'Container',
+    # 'Canvas',
+    # 'DetailedList',
+    # 'Icon',
+    # 'Image',
+    # 'ImageView',
     'Label',
     'MultilineTextInput',
     'NumberInput',
+    # 'OptionContainer',
     'PasswordInput',
+    # 'ProgressBar',
+    # 'ScrollContainer',
+    # 'Selection',
+    # 'Slider',
+    # 'SplitContainer',
+    # 'Switch',
+    # 'Table',
     'TextInput',
+    # 'Tree',
+    # 'WebView',
+    'Window',
 ]
 
 # Examples of valid version strings

--- a/src/win32/toga_win32/app.py
+++ b/src/win32/toga_win32/app.py
@@ -1,7 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
-import ctypes
-
 from .libs import *
 from .window import Window
 

--- a/src/win32/toga_win32/libs/__init__.py
+++ b/src/win32/toga_win32/libs/__init__.py
@@ -33,13 +33,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
-from __future__ import print_function, absolute_import, division
-
 from .constants import *
 from .debug import *
-
 from .gdi32 import *
 from .kernel32 import *
-from .user32 import *
-
 from .macro_equivalents import *
+from .user32 import *

--- a/src/win32/toga_win32/libs/debug.py
+++ b/src/win32/toga_win32/libs/debug.py
@@ -1,8 +1,6 @@
-from __future__ import print_function, absolute_import, division
-
 from ctypes import *
-from . import constants
 
+from . import constants
 
 _debug_win32 = True
 

--- a/src/win32/toga_win32/libs/key.py
+++ b/src/win32/toga_win32/libs/key.py
@@ -1,7 +1,5 @@
-from __future__ import print_function, absolute_import, division
-
-from ..window import key
 from .constants import *
+from ..window import key
 
 keymap = {
     ord('A'): key.A,

--- a/src/win32/toga_win32/libs/types.py
+++ b/src/win32/toga_win32/libs/types.py
@@ -1,8 +1,5 @@
-from __future__ import print_function, absolute_import, division
-
 from ctypes import *
 from ctypes.wintypes import *
-
 
 INT = c_int
 LPVOID = c_void_p

--- a/src/win32/toga_win32/libs/user32.py
+++ b/src/win32/toga_win32/libs/user32.py
@@ -1,10 +1,7 @@
-from __future__ import print_function, absolute_import, division
-
 import struct
 
 from .debug import DebugLibrary
 from .types import *
-
 
 IS64 = struct.calcsize("P") == 8
 

--- a/src/win32/toga_win32/widgets/base.py
+++ b/src/win32/toga_win32/widgets/base.py
@@ -1,9 +1,10 @@
-from __future__ import print_function, absolute_import, division
+from ctypes import c_wchar_p
 
 from toga_cassowary.widget import Widget as CassowaryWidget
-from ..libs.constants import *
+
 from ..libs import user32
-from ctypes import c_wchar_p
+from ..libs.constants import *
+
 
 class Widget(CassowaryWidget):
     window_class = None

--- a/src/win32/toga_win32/widgets/button.py
+++ b/src/win32/toga_win32/widgets/button.py
@@ -1,7 +1,6 @@
-from __future__ import print_function, absolute_import, division
+from .base import Widget
 from ..libs import *
 
-from .base import Widget
 
 def wrapped_handler(widget, handler):
     def _handler(impl, data=None):

--- a/src/win32/toga_win32/widgets/container.py
+++ b/src/win32/toga_win32/widgets/container.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from toga_cassowary.widget import Container as CassowaryContainer
 
 

--- a/src/win32/toga_win32/widgets/label.py
+++ b/src/win32/toga_win32/widgets/label.py
@@ -1,9 +1,8 @@
-from __future__ import print_function, absolute_import, division
-
-from ..libs import *
 from toga.constants import LEFT_ALIGNED, RIGHT_ALIGNED
 
 from .base import Widget
+from ..libs import *
+
 
 class Label(Widget):
     window_class = 'static'

--- a/src/win32/toga_win32/widgets/textinput.py
+++ b/src/win32/toga_win32/widgets/textinput.py
@@ -1,9 +1,8 @@
-from __future__ import print_function, absolute_import, division
-
-from ..libs import *
 from ctypes import c_wchar_p
 
 from .base import Widget
+from ..libs import *
+
 
 class TextInput(Widget):
     window_class = 'edit'

--- a/src/win32/toga_win32/window.py
+++ b/src/win32/toga_win32/window.py
@@ -1,8 +1,6 @@
-from __future__ import print_function, absolute_import, division
+import ctypes
 
 from .libs import *
-
-import ctypes
 
 
 class Window(object):

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -1,9 +1,9 @@
 #/usr/bin/env python
 import io
 import re
-from setuptools import setup, find_packages
 import sys
 
+from setuptools import setup, find_packages
 
 if sys.version_info[:3] < (3, 4):
     raise SystemExit("Toga requires Python 3.4+.")

--- a/src/winforms/tests/test_implementation.py
+++ b/src/winforms/tests/test_implementation.py
@@ -1,4 +1,5 @@
 import os
+
 from toga_dummy import test_implementation
 
 globals().update(

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -1,9 +1,4 @@
-import os
-
-from .libs import *
-
 from .window import Window
-# from .widgets.icon import Icon, TIBERIUS_ICON
 
 
 class MainWindow(Window):

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -1,30 +1,15 @@
-# Core capabilities
 from .app import *
-from .window import *
 from .command import *
-
-# Font support
-# from .font import Font
-
-# Widgets
 from .widgets.box import *
 from .widgets.button import *
 from .widgets.icon import *
-# from .widgets.image import *
-# from .widgets.imageview import *
 from .widgets.label import *
 from .widgets.multilinetextinput import *
 from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
-# from .widgets.splitcontainer import *
 from .widgets.table import *
-from .widgets.textinput import *
-# from .widgets.tree import *
 from .widgets.webview import *
-# # from .widgets.selection import Selection
-# from .widgets.numberinput import NumberInput
 
 __all__ = [
     '__version__',
@@ -34,20 +19,14 @@ __all__ = [
     'Box',
     'Button',
     'Icon', 'TIBERIUS_ICON',
-    # 'Image',
-    # 'ImageView',
-    # 'Font',
     'Label',
     'MultilineTextInput',
     'NumberInput',
     'OptionContainer',
     'ProgressBar',
     'ScrollContainer',
-    # 'Selection',
-    # 'SplitContainer',
     'Table',
     'TextInput',
     'PasswordInput',
-    # 'Tree',
     'WebView',
 ]

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -1,32 +1,55 @@
-from .app import *
-from .command import *
-from .widgets.box import *
-from .widgets.button import *
-from .widgets.icon import *
+from .app import App, MainWindow
+from .command import Command
+# from .font import Font
+from .widgets.box import Box
+from .widgets.button import Button
+# from .widgets.canvas import Canvas
+# from .widgets.detailedlist import DetailedList
+from .widgets.icon import Icon
+# from .widgets.image import *
+# from .widgets.imageview import *
 from .widgets.label import *
 from .widgets.multilinetextinput import *
+# from .widgets.numberinput import NumberInput
 from .widgets.optioncontainer import *
 from .widgets.passwordinput import *
 from .widgets.progressbar import *
+# from .widgets.scrollcontainer import *
+# from .widgets.selection import Selection
+# from .widgets.slider import *
+# from .widgets.splitcontainer import *
+# from .widgets.switch import *
 from .widgets.table import *
+from .widgets.textinput import *
+# from .widgets.tree import *
 from .widgets.webview import *
+from .window import Window
 
 __all__ = [
-    '__version__',
     'App', 'MainWindow',
-    'Window',
     'Command',
+    # 'Font',
     'Box',
     'Button',
-    'Icon', 'TIBERIUS_ICON',
+    # 'Canvas',
+    # 'DetailedList',
+    'Icon',
+    # 'Image',
+    # 'ImageView',
     'Label',
     'MultilineTextInput',
     'NumberInput',
     'OptionContainer',
+    'PasswordInput',
     'ProgressBar',
     'ScrollContainer',
+    # 'Selection',
+    # 'Slider',
+    # 'SplitContainer',
+    # 'Switch',
     'Table',
     'TextInput',
-    'PasswordInput',
+    # 'Tree',
     'WebView',
+    'Window',
 ]

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -1,7 +1,5 @@
 import clr
 clr.AddReference("System.Windows.Forms")
 
-from System import Uri, Threading
-from System.Drawing import Size, Point, Color
 import System.Windows.Forms as WinForms
 from System import Decimal as ClrDecimal

--- a/src/winforms/toga_winforms/widgets/label.py
+++ b/src/winforms/toga_winforms/widgets/label.py
@@ -1,5 +1,3 @@
-from toga.constants import LEFT_ALIGNED
-
 from toga_winforms.libs import *
 
 from .base import Widget

--- a/src/winforms/toga_winforms/widgets/progressbar.py
+++ b/src/winforms/toga_winforms/widgets/progressbar.py
@@ -1,4 +1,5 @@
 from toga_winforms.libs import *
+
 from .base import Widget
 
 

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -1,4 +1,5 @@
 from toga_winforms.libs import *
+
 from .base import Widget
 
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -1,9 +1,5 @@
-from .libs import *
-
 from .container import Container
-from . import dialogs
-# from .command import SEPARATOR, SPACER, EXPANDING_SPACER
-
+from .libs import *
 
 
 class Window:


### PR DESCRIPTION
I would like to see as part of our Beekeeper checks us run pyflakes/pep8 style checks. It would help improve quality, consistency, and people rather hear nitpicky stuff from a computer rather than a human :)

As part of getting ready for this, I have started with cleanup all of the import statements to align with the Google formatting:
Imports should be grouped with the order being most generic to least generic:

    standard library imports
    third-party imports
    application-specific imports

Within each grouping, imports should be sorted lexicographically, ignoring case, according to each module's full package path. 