### PR TITLE
Ref #299 - Correct usage of arguments on Button.set_label

### DIFF
--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -27,7 +27,7 @@ class Button(Widget):
         self.native.setOnClickListener(self._listener)
 
     def set_label(self, label):
-        self.native.setText(self.label)
+        self.native.setText(self.interface.label)
 
     def set_enabled(self, value):
         pass

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -32,7 +32,7 @@ class Button(Widget):
             self.native.font = value._impl.native
 
     def set_label(self, label):
-        self.native.title = label
+        self.native.title = self.interface.label
 
     def set_on_press(self, handler):
         pass

--- a/src/core/toga/widgets/button.py
+++ b/src/core/toga/widgets/button.py
@@ -41,7 +41,7 @@ class Button(Widget):
             self._label = ''
         else:
             self._label = str(value)
-        self._impl.set_label(self.label)
+        self._impl.set_label(value)
         self._impl.rehint()
 
     @property

--- a/src/dummy/toga_dummy/widgets/button.py
+++ b/src/dummy/toga_dummy/widgets/button.py
@@ -6,7 +6,7 @@ class Button(Widget):
         self._action('create Button')
 
     def set_label(self, label):
-        self._set_value('label', label)
+        self._set_value('label', self.interface.label)
 
     def set_on_press(self, handler):
         self._set_value('on_press', handler)

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -13,7 +13,7 @@ class Button(Widget):
         self.native.connect('clicked', self.on_press)
 
     def set_label(self, label):
-        self.native.set_label(label)
+        self.native.set_label(self.interface.label)
         self.rehint()
 
     def set_enabled(self, value):

--- a/src/iOS/toga_iOS/widgets/button.py
+++ b/src/iOS/toga_iOS/widgets/button.py
@@ -26,7 +26,7 @@ class Button(Widget):
         self.add_constraints()
 
     def set_label(self, label):
-        self.native.setTitle(label, forState=UIControlStateNormal)
+        self.native.setTitle(self.interface.label, forState=UIControlStateNormal)
 
     def set_on_press(self, handler):
         pass

--- a/src/win32/toga_win32/widgets/button.py
+++ b/src/win32/toga_win32/widgets/button.py
@@ -14,7 +14,7 @@ class Button(Widget):
     control_style = BS_DEFPUSHBUTTON | BS_TEXT
 
     def __init__(self, label, on_press=None):
-        super(Button, self).__init__(text=label)
+        super(Button, self).__init__(text=self.interface.label)
         self._expand_vertical = False
         self.on_press = on_press
 

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -21,7 +21,7 @@ class Button(Widget):
         self.native = TogaButton(self.interface)
 
     def set_label(self, label):
-        self.native.Text = label
+        self.native.Text = self.interface.label
         self.rehint()
 
     def set_enabled(self, value):


### PR DESCRIPTION
Only for widgets/button
- changed `set_label` in src/core/toga/widgets/button.py to pass down literal argument
- changed each implementation (Cocoa, Gtk+, etc) to use `self.interface.label` instead of `label` so that they use values from interface
- passes all testcases