### PR TITLE
Fixes #314 - Clarified handling of viewport and sublayouts.

### DIFF
--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -41,7 +41,9 @@ class Graze(toga.App):
         self.webview.url = self.url_input.value
 
 
-if __name__ == '__main__':
-    app = Graze('Graze', 'org.pybee.graze')
+def main():
+    return Graze('Graze', 'org.pybee.graze')
 
-    app.main_loop()
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -114,9 +114,9 @@ class StartApp(toga.App):
         self.draw_text()
 
 
-if __name__ == '__main__':
-    # Application class
-    #   App name and namespace
-    app = StartApp('Tutorial 4', 'org.pybee.helloworld')
+def main():
+    return StartApp('Tutorial 4', 'org.pybee.helloworld')
 
-    app.main_loop()
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -7,6 +7,7 @@ class Widget:
         self.interface._impl = self
         self._container = None
         self.constraints = None
+        self.viewport = None
         self.native = None
         self.create()
         self.interface.style.reapply()
@@ -24,9 +25,8 @@ class Widget:
     @container.setter
     def container(self, container):
         self._container = container
-        if self.constraints:
-            self._container.native.addSubview(self.native)
-            self.constraints.container = container
+        self._container.native.addSubview(self.native)
+        self.constraints.container = container
 
         for child in self.interface.children:
             child._impl.container = container
@@ -63,7 +63,6 @@ class Widget:
 
     def add_child(self, child):
         if self.container:
-            child.viewport = self.root.viewport
             child.container = self.container
 
     def add_constraints(self):

--- a/src/cocoa/toga_cocoa/widgets/splitcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/splitcontainer.py
@@ -25,11 +25,12 @@ class TogaSplitViewDelegate(NSObject):
     @objc_method
     def splitViewDidResizeSubviews_(self, notification) -> None:
         # If the window is actually visible, and the split has moved,
-        # a resize of all the content panels is required.
+        # a resize of all the content panels is required. The refresh
+        # needs to be directed at the root container holding the widget,
+        # as the splitview may not be the root container.
         if self.interface.window and self.interface.window._impl.native.isVisible:
-            # print("SPLIT CONTAINER LAYOUT CHILDREN", self.interface._impl.containers[0].native.frame.size.width, self.interface._impl.containers[1].native.frame.size.width)
             self.interface.refresh()
-            self.interface._impl.on_resize()
+            self._impl.on_resize()
 
 
 class SplitContainer(Widget):

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -152,8 +152,11 @@ class Window:
         self.native.setToolbar_(self._toolbar_native)
 
     def set_content(self, widget):
+        # Set the window's view to the be the widget's native object.
         self.native.contentView = widget.native
-        widget.viewport = CocoaViewport(self.native.contentView)
+
+        # Set the widget's viewport to be based on the window's content.
+        widget.viewport = CocoaViewport(widget.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -108,6 +108,7 @@ class Widget(Node):
         self._window = window
         if self._impl:
             self._impl.set_window(window)
+
         if self._children is not None:
             for child in self._children:
                 child.window = window
@@ -123,8 +124,11 @@ class Widget(Node):
 
     def refresh(self):
         """Refresh the layout and appearance of the tree this node is contained in."""
-        super().refresh(self._impl.viewport)
-        self.refresh_sublayouts()
+        if self._root:
+            self._root.refresh()
+        else:
+            super().refresh(self._impl.viewport)
+            self.refresh_sublayouts()
 
     def refresh_sublayouts(self):
         if self._children is not None:

--- a/src/core/toga/widgets/scrollcontainer.py
+++ b/src/core/toga/widgets/scrollcontainer.py
@@ -90,5 +90,4 @@ class ScrollContainer(Widget):
 
     def refresh_sublayouts(self):
         """Refresh the layout and appearance of this widget."""
-        for widget in self._content:
-            widget.refresh()
+        self._content.refresh()

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -5,8 +5,8 @@ class Widget:
     def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
-
         self._container = None
+        self.viewport = None
         self.native = None
         self.create()
         self.interface.style.reapply()
@@ -60,7 +60,6 @@ class Widget:
 
     def add_child(self, child):
         if self.container:
-            child.viewport = self.root.viewport
             child.container = self.container
 
     def rehint(self):

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk
+from travertino.size import at_least
 
 
 class Widget:
@@ -63,4 +64,9 @@ class Widget:
             child.container = self.container
 
     def rehint(self):
-        pass
+        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
+        width = self.native.get_preferred_width()
+        height = self.native.get_preferred_height()
+
+        self.interface.intrinsic.width = at_least(width[0])
+        self.interface.intrinsic.height = at_least(height[0])

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -37,28 +37,29 @@ class TogaBox(Gtk.Fixed):
 
     def do_size_allocate(self, allocation):
         # print(self._impl, "Container layout", allocation.width, 'x', allocation.height, ' @ ', allocation.x, 'x', allocation.y)
-        self.set_allocation(allocation)
-        self.interface.refresh()
+        if self._impl.viewport is not None:
+            self.set_allocation(allocation)
+            self.interface.refresh()
 
-        # WARNING! This list of children is *not* the same
-        # as the list provided by the interface!
-        # For GTK's layout purposes, all widgets in the tree
-        # are children of the *container* - that is, the impl
-        # object of the root object in the tree of widgets.
-        for widget in self.get_children():
-            if not widget.get_visible():
-                # print("CHILD NOT VISIBLE", widget.interface)
-                pass
-            else:
-                # print("update ", widget.interface, widget.interface.layout)
-                widget.interface._impl.rehint()
-                widget_allocation = Gdk.Rectangle()
-                widget_allocation.x = widget.interface.layout.absolute_content_left
-                widget_allocation.y = widget.interface.layout.absolute_content_top
-                widget_allocation.width = widget.interface.layout.content_width
-                widget_allocation.height = widget.interface.layout.content_height
+            # WARNING! This list of children is *not* the same
+            # as the list provided by the interface!
+            # For GTK's layout purposes, all widgets in the tree
+            # are children of the *container* - that is, the impl
+            # object of the root object in the tree of widgets.
+            for widget in self.get_children():
+                if not widget.get_visible():
+                    # print("CHILD NOT VISIBLE", widget.interface)
+                    pass
+                else:
+                    # print("update ", widget.interface, widget.interface.layout)
+                    widget.interface._impl.rehint()
+                    widget_allocation = Gdk.Rectangle()
+                    widget_allocation.x = widget.interface.layout.absolute_content_left
+                    widget_allocation.y = widget.interface.layout.absolute_content_top
+                    widget_allocation.width = widget.interface.layout.content_width
+                    widget_allocation.height = widget.interface.layout.content_height
 
-                widget.size_allocate(widget_allocation)
+                    widget.size_allocate(widget_allocation)
 
 
 class Box(Widget):

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -11,7 +11,7 @@ class TogaBox(Gtk.Fixed):
 
     def do_get_preferred_width(self):
         # Calculate the minimum and natural width of the container.
-        # print("GET PREFERRED WIDTH")
+        # print("GET PREFERRED WIDTH", self._impl.native)
         width = self._impl.interface.layout.width
         min_width = self._impl.min_width
         if min_width is None:
@@ -25,7 +25,7 @@ class TogaBox(Gtk.Fixed):
     def do_get_preferred_height(self):
         # Calculate the minimum and natural height of the container.
         # height = self._impl.layout.height
-        # print("GET PREFERRED HEIGHT")
+        # print("GET PREFERRED HEIGHT", self._impl.native)
         height = self._impl.interface.layout.height
         min_height = self._impl.min_height
         if min_height is None:

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -73,12 +73,8 @@ class Window:
             self.toolbar_native.insert(item_impl, -1)
 
     def set_content(self, widget):
-        widget.viewport = GtkViewport(widget.native)
-
-        # Add all children to the content widget.
-        for child in widget.interface.children:
-            child._impl.container = widget
-
+        # Construct the top-level layout, and set the window's view to
+        # the be the widget's native object.
         self.layout = Gtk.VBox()
 
         if self.toolbar_native:
@@ -87,7 +83,15 @@ class Window:
 
         self.native.add(self.layout)
 
+        # Make the window sensitive to size changes
         widget.native.connect('size-allocate', self.on_size_allocate)
+
+        # Set the widget's viewport to be based on the window's content.
+        widget.viewport = GtkViewport(widget.native)
+
+        # Add all children to the content widget.
+        for child in widget.interface.children:
+            child._impl.container = widget
 
     def show(self):
         self.native.show_all()

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -61,7 +61,6 @@ class Widget:
 
     def add_child(self, child):
         if self.container:
-            child.viewport = self.root.viewport
             child.container = self.container
 
     def rehint(self):

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -52,18 +52,23 @@ class Window:
         pass
 
     def set_content(self, widget):
+        # If the content widget doesn't have a native, manifest a Panel as that native.
         if widget.native is None:
             widget.native = WinForms.Panel()
+
+        # Construct the top-level layout, and set the window's view to
+        # the be the widget's native object.
+        if self.toolbar_native:
+            self.native.Controls.Add(self.toolbar_native)
+
+        self.native.Controls.Add(widget.native)
+
+        # Set the widget's viewport to be based on the window's content.
         widget.viewport = WinFormsViewport(self.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
-
-        if self.toolbar_native:
-            self.native.Controls.Add(self.toolbar_native)
-
-        self.native.Controls.Add(widget.native)
 
     def set_title(self, title):
         self.native.Text = title


### PR DESCRIPTION
@danyeaw pointed out that viewport was being exposed at the interface layer, which lead to some cleanups around assigning viewport.

However, the real fix was around the native widget behind Box - since it's a toga widget, *every* box was getting a Gtk resize signal, leading to a redraw. However, only the top level widget needs to recompute the layout, so the layout can be ignored for every box *except* the one that has a viewport (which flags it as the top-level widget).