### PR TITLE
Make Table a subclass of Tree [GTK]

### DIFF
--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -1,33 +1,12 @@
 from gi.repository import Gtk
 
-from .base import Widget
+from .tree import Tree
 
 
-class Table(Widget):
-    def create(self):
-        self.store = Gtk.ListStore(*[object] + [str for h in self.interface.headings])
-
-        # Create a table view, and put it in a scroll view.
-        # The scroll view is the native, because it's the outer container.
-        self.treeview = Gtk.TreeView(model=self.store)
-        self.selection = self.treeview.get_selection()
-        self.selection.set_mode(Gtk.SelectionMode.SINGLE)
-        self.selection.connect("changed", self.on_select)
-
-        for i, heading in enumerate(self.interface.headings):
-            renderer = Gtk.CellRendererText()
-            column = Gtk.TreeViewColumn(heading, renderer, text=i + 1)
-            self.treeview.append_column(column)
-
-        self.native = Gtk.ScrolledWindow()
-        self.native.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        self.native.add(self.treeview)
-        # self.native.set_min_content_width(200)
-        # self.native.set_min_content_height(200)
-        self.native.interface = self.interface
+class Table(Tree):
 
     def on_select(self, selection):
-        if self.interface.on_select:
+        if hasattr(self.interface, "on_select") and self.interface.on_select:
             tree_model, tree_iter = selection.get_selected()
             if tree_iter:
                 row = tree_model.get(tree_iter, 0)[0]
@@ -35,46 +14,40 @@ class Table(Widget):
                 row = None
             self.interface.on_select(None, row=row)
 
-    def row_data(self, row):
-        return [row] + [
-            str(getattr(row, attr))
-            for attr in self.interface._accessors
-        ]
-
     def change_source(self, source):
-        """
-        Synchronize self.data with self.interface.data
-        """
-
         # Temporarily disconnecting the TreeStore improves performance for large
         # updates by deferring row rendering until the update is complete.
-        self.treeview.set_model(None) # temporarily disconnect the view
+        self.treeview.set_model(None)
 
         self.store.clear()
+
         for i, row in enumerate(self.interface.data):
             self.insert(i, row)
 
         self.treeview.set_model(self.store)
 
-    def insert(self, index, item):
-        impl = self.store.insert(index, self.row_data(item))
-        try:
-            item._impl[self] = impl
-        except AttributeError:
-            item._impl = {self: impl}
+    def insert(self, index, item, **kwargs):
+        super().insert(None, index, item, **kwargs)
 
-    def change(self, item):
-        self.store[item._impl[self]] = self.row_data(item)
+    # =================================
+    # UNCHANGED METHODS (inherited from Tree)
+    # They are included here only to satisfy the implementation tests, which
+    # do not currently check for inherited methods.
 
-    def remove(self, item):
-        del self.store[item._impl[self]]
-        del item._impl[self]
-
-    def clear(self):
-        self.store.clear()
-
-    def set_on_select(self, handler):
-        pass
+    def create(self):
+        super().create()
 
     def scroll_to_row(self, row):
-        raise NotImplementedError()
+        super().scroll_to_row(row)
+
+    def change(self, item):
+        super().change(item)
+
+    def remove(self, item):
+        super().remove(item)
+
+    def clear(self):
+        super().clear()
+
+    def set_on_select(self, handler):
+        super().set_on_select(handler)

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -6,7 +6,7 @@ from .tree import Tree
 class Table(Tree):
 
     def on_select(self, selection):
-        if hasattr(self.interface, "on_select") and self.interface.on_select:
+        if self.interface.on_select:
             tree_model, tree_iter = selection.get_selected()
             if tree_iter:
                 row = tree_model.get(tree_iter, 0)[0]
@@ -29,6 +29,9 @@ class Table(Tree):
     def insert(self, index, item, **kwargs):
         super().insert(None, index, item, **kwargs)
 
+    def scroll_to_row(self, row):
+        return NotImplementedError
+
     # =================================
     # UNCHANGED METHODS (inherited from Tree)
     # They are included here only to satisfy the implementation tests, which
@@ -36,9 +39,6 @@ class Table(Tree):
 
     def create(self):
         super().create()
-
-    def scroll_to_row(self, row):
-        super().scroll_to_row(row)
 
     def change(self, item):
         super().change(item)

--- a/src/gtk/toga_gtk/widgets/tree.py
+++ b/src/gtk/toga_gtk/widgets/tree.py
@@ -33,7 +33,7 @@ class Tree(Widget):
         ]
 
     def on_select(self, selection):
-        if hasattr(self.interface, "on_select") and self.interface.on_select:
+        if self.interface.on_select:
             tree_model, tree_iter = selection.get_selected()
             if tree_iter:
                 node = tree_model.get(tree_iter, 0)[0]
@@ -81,5 +81,5 @@ class Tree(Widget):
     def set_on_select(self, handler):
         pass
 
-    def scroll_to_row(self, row):
+    def scroll_to_node(self, node):
         raise NotImplementedError

--- a/src/gtk/toga_gtk/widgets/tree.py
+++ b/src/gtk/toga_gtk/widgets/tree.py
@@ -80,3 +80,6 @@ class Tree(Widget):
 
     def set_on_select(self, handler):
         pass
+
+    def scroll_to_row(self, row):
+        raise NotImplementedError


### PR DESCRIPTION
Note that several "empty" methods that wrap `super()` are included in order to
make the tests happy (since the tests do not look for inherited methods). Look to line 37, `create()` for an example of one such method.

I'd be great to have the tests realize that the methods are implemented by the base class, so that these empty wrappers can be removed. (Gtk Table would then be only ~30 lines long!) I dug around a bit in `toga_dummy/test_implementation.py` and found `methods_of_class()`, which finds methods in a class by syntax. I quote a comment: "Warnings:
            Does not return inherited methods. Only methods that are present in the class and the actual .py file."

Is it a desirable feature to have the tests go deeper than syntax and find inherited methods? If it is, I'll gladly take a stab at it.

Other than that, Table still works in the example app. I'll certainly be happy to not feel like I'm writing the same code twice for Table and Tree :)

Signed-off-by: Drew Meier <darius.montez@gmail.com>