### PR TITLE
Ref #299 - Correct usage of arguments on Label.set_text

### DIFF
--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -26,7 +26,7 @@ class Label(Widget):
             }[value])
 
     def set_text(self, value):
-        self.native.setText(value)
+        self.native.setText(self.interface._text)
 
     def rehint(self):
         # print("REHINT label", self, self.native.getMeasuredWidth(), self.native.getMeasuredHeight())

--- a/src/cocoa/toga_cocoa/widgets/label.py
+++ b/src/cocoa/toga_cocoa/widgets/label.py
@@ -31,7 +31,7 @@ class Label(Widget):
             self.native.font = value._impl.native
 
     def set_text(self, value):
-        self.native.stringValue = value
+        self.native.stringValue = self.interface._text
 
     def rehint(self):
         # Width & height of a label is known and fixed.

--- a/src/core/toga/widgets/label.py
+++ b/src/core/toga/widgets/label.py
@@ -36,5 +36,5 @@ class Label(Widget):
             self._text = ''
         else:
             self._text = str(value)
-        self._impl.set_text(value)
+        self._impl.set_text(self._text)
         self._impl.rehint()

--- a/src/core/toga/widgets/label.py
+++ b/src/core/toga/widgets/label.py
@@ -36,5 +36,5 @@ class Label(Widget):
             self._text = ''
         else:
             self._text = str(value)
-        self._impl.set_text(self._text)
+        self._impl.set_text(value)
         self._impl.rehint()

--- a/src/django/toga_django/widgets/label.py
+++ b/src/django/toga_django/widgets/label.py
@@ -12,7 +12,7 @@ class Label(Widget):
         )
 
     def set_text(self, value):
-        self._impl.innerText = value
+        self._impl.innerText = self.interface._text
 
     def set_alignment(self, value):
         raise NotImplementedError()

--- a/src/dummy/toga_dummy/widgets/label.py
+++ b/src/dummy/toga_dummy/widgets/label.py
@@ -9,7 +9,7 @@ class Label(Widget):
         self._set_value('alignment', value)
 
     def set_text(self, value):
-        self._set_value('text', value)
+        self._set_value('text', self.interface._text)
 
     def rehint(self):
         self._action('rehint Label')

--- a/src/gtk/toga_gtk/widgets/label.py
+++ b/src/gtk/toga_gtk/widgets/label.py
@@ -37,7 +37,7 @@ class Label(Widget):
     def set_text(self, value):
         # FIXME after setting the label the label jumps to the top left
         # corner and only jumps back at its place after resizing the window.
-        self.native.set_text(value)
+        self.native.set_text(self.interface._text)
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height(), getattr(self, '_fixed_height', False), getattr(self, '_fixed_width', False))

--- a/src/iOS/toga_iOS/widgets/label.py
+++ b/src/iOS/toga_iOS/widgets/label.py
@@ -31,7 +31,7 @@ class Label(Widget):
             self.native.font = value._impl.native
 
     def set_text(self, value):
-        self.native.setText_(value)
+        self.native.setText_(self.interface._text)
 
     def rehint(self):
         # Width & height of a label is known and fixed.

--- a/src/win32/toga_win32/widgets/label.py
+++ b/src/win32/toga_win32/widgets/label.py
@@ -10,7 +10,7 @@ class Label(Widget):
 
 
     def __init__(self, text=None, alignment=LEFT_ALIGNED):
-        super(Label, self).__init__(text=text)
+        super(Label, self).__init__(text=self.interface._text)
         self.alignment = alignment
         alignments = {LEFT_ALIGNED: SS_LEFT, RIGHT_ALIGNED: SS_RIGHT}
         alignment = alignments[self.alignment]

--- a/src/winforms/toga_winforms/widgets/label.py
+++ b/src/winforms/toga_winforms/widgets/label.py
@@ -13,7 +13,7 @@ class Label(Widget):
         self.native.TextAlign = TextAlignment(value)
 
     def set_text(self, value):
-        self.native.Text = value
+        self.native.Text = self.interface._text
 
     def rehint(self):
         # Width & height of a label is known and fixed.


### PR DESCRIPTION
For widgets/label

- changed set_text in src/core/toga/widgets/label.py to pass down literal argument

- changed each implementation (Cocoa, Gtk+, etc) to use self.interface._text so that they use values from interface