### PR TITLE
Added documentation and audited NumberInput

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -89,7 +89,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("min_value must be an integer")
         except TypeError:
-            self._min_value = (-179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497791)
+            self._min_value = int(-1.7976931348623157e+308)
         self._impl.set_min_value(self._min_value)
 
     @property
@@ -109,7 +109,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("max_value must be an integer")
         except TypeError:
-            self._max_value = (179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497791)
+            self._max_value = int(1.7976931348623157e+308)
         self._impl.set_max_value(self._max_value)
 
     @property
@@ -135,7 +135,7 @@ class NumberInput(Widget):
             self._value = self.min_value
         elif self.max_value is not None and value > self.max_value:
             self._value = self.max_value
-        self._impl.set_value(self._value)
+        self._impl.set_value(value)
 
     @property
     def on_change(self):

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -1,4 +1,5 @@
 from toga.handlers import wrapped_handler
+from sys import maxsize
 
 from .base import Widget
 
@@ -89,7 +90,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("min_value must be an integer")
         except TypeError:
-            self._min_value = int(-1.7976931348623157e+308)
+            self._min_value = -maxsize - 1
         self._impl.set_min_value(self._min_value)
 
     @property
@@ -109,7 +110,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("max_value must be an integer")
         except TypeError:
-            self._max_value = int(1.7976931348623157e+308)
+            self._max_value = maxsize
         self._impl.set_max_value(self._max_value)
 
     @property

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -15,6 +15,10 @@ class NumberInput(Widget):
             implementation of this class with the same name. (optional & normally not needed)
 
         step (int): Step size of the adjustment buttons.
+        min_value (int): The minimum bound for the widget's value.
+        max_value (int): The maximum bound for the widget's value.
+        readonly (bool):  Whether a user can write/change the number input, defaults to `False`.
+        on_change (``callable``): The handler to invoke when the value changes.
         **ex:
     """
     MIN_WIDTH = 100
@@ -33,7 +37,7 @@ class NumberInput(Widget):
 
     @property
     def readonly(self):
-        """ Whether a user can write into the text input
+        """ Whether a user can write/change the number input
 
         Returns:
             ``True`` if only read is possible.
@@ -61,7 +65,7 @@ class NumberInput(Widget):
             self._step = int(step)
         except (ValueError, TypeError):
             raise ValueError("step must be an integer")
-        self._impl.set_step(step)
+        self._impl.set_step(self._step)
 
     @property
     def min_value(self):
@@ -81,7 +85,7 @@ class NumberInput(Widget):
             raise ValueError("min_value must be an integer")
         except TypeError:
             self._min_value = None
-        self._impl.set_min_value(value)
+        self._impl.set_min_value(self._min_value)
 
     @property
     def max_value(self):
@@ -101,7 +105,7 @@ class NumberInput(Widget):
             raise ValueError("max_value must be an integer")
         except TypeError:
             self._max_value = None
-        self._impl.set_max_value(value)
+        self._impl.set_max_value(self._max_value)
 
     @property
     def value(self):
@@ -126,7 +130,7 @@ class NumberInput(Widget):
             self._value = self.min_value
         elif self.max_value is not None and value > self.max_value:
             self._value = self.max_value
-        self._impl.set_value(value)
+        self._impl.set_value(self._value)
 
     @property
     def on_change(self):

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -27,6 +27,11 @@ class NumberInput(Widget):
                  min_value=None, max_value=None, readonly=False, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
         self._value = None
+        # Needed for _impl initialization
+        self._min_value = 0
+        self._max_value = 0
+        self._step = 1
+        
         self._impl = self.factory.NumberInput(interface=self)
 
         self.readonly = readonly
@@ -84,7 +89,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("min_value must be an integer")
         except TypeError:
-            self._min_value = None
+            self._min_value = (-179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497791)
         self._impl.set_min_value(self._min_value)
 
     @property
@@ -104,7 +109,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("max_value must be an integer")
         except TypeError:
-            self._max_value = None
+            self._max_value = (179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497791)
         self._impl.set_max_value(self._max_value)
 
     @property

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -5,12 +5,12 @@ from .base import Widget
 
 class NumberInput(Widget):
     def create(self):
-        adjustment = Gtk.Adjustment(0, self.interface.min_value,
+        self.adjustment = Gtk.Adjustment(0, self.interface.min_value,
                                     self.interface.max_value,
                                     self.interface.step, 10, 0)
 
         self.native = Gtk.SpinButton()
-        self.native.set_adjustment(adjustment)
+        self.native.set_adjustment(self.adjustment)
         self.native.set_numeric(True)
         self.native.interface = self.interface
 
@@ -20,13 +20,16 @@ class NumberInput(Widget):
         self.native.editable = not value
 
     def set_step(self, step):
-        raise NotImplementedError()
+        self.adjustment.set_step_increment(step)
+        self.native.set_adjustment(self.adjustment)
 
     def set_min_value(self, value):
-        raise NotImplementedError()
+        self.adjustment.set_lower(value)
+        self.native.set_adjustment(self.adjustment)
 
     def set_max_value(self, value):
-        raise NotImplementedError()
+        self.adjustment.set_upper(value)
+        self.native.set_adjustment(self.adjustment)
 
     def set_value(self, value):
         self.native.set_value(value)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Completed the documentation for NumberInput widget in core file and also audited it.

<!--- What problem does this change solve? -->
The value from the user was directly getting passed to the platform implementation layer without getting checked as in case when a value of type integer should be passed rather than of type string. Therefore, I instead of passing the value from the user passed the property' value to which the original value passed by the user is getting assigned to after the check.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
