### PR TITLE
Replace NotImplementedError with a soft, logging option.

### DIFF
--- a/src/android/toga_android/dialogs.py
+++ b/src/android/toga_android/dialogs.py
@@ -14,25 +14,21 @@ def info(window, title, message):
 
 
 def question(window, title, message):
-    # TODO
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.question()')
 
 
 def confirm(window, title, message):
-    # TODO
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.confirm()')
 
 
 def error(window, title, message):
-    # TODO
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.error()')
 
 
 def stack_trace(window, title, message, content, retry=False):
-    # TODO
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.stack_trace()')
 
 
 def save_file(window, title, suggested_filename, file_types):
-    # TODO
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.save_file()')
+

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -26,7 +26,14 @@ from .widgets.textinput import TextInput
 # from .widgets.webview import *
 from .window import Window
 
+
+def not_implemented(feature):
+    print('[GTK backend] Not implemented: {}'.format(feature))
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     # 'color',
     # 'Command',

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -28,7 +28,7 @@ from .window import Window
 
 
 def not_implemented(feature):
-    print('[GTK backend] Not implemented: {}'.format(feature))
+    print('[Android] Not implemented: {}'.format(feature))
 
 
 __all__ = [

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -40,7 +40,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        raise NotImplementedError()
+        self.platform.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -40,7 +40,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        self.platform.not_implemented('Widget.set_hidden()')
+        self.interface.factory.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -30,10 +30,10 @@ class Button(Widget):
         self.native.setText(self.interface.label)
 
     def set_enabled(self, value):
-        self.platform.not_implemented('Button.set_enabled()')
+        self.interface.factory.not_implemented('Button.set_enabled()')
 
     def set_background_color(self, value):
-        self.platform.not_implemented('Button.set_background_color()')
+        self.interface.factory.not_implemented('Button.set_background_color()')
 
     def set_on_press(self, handler):
         # No special handling required

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -30,10 +30,10 @@ class Button(Widget):
         self.native.setText(self.interface.label)
 
     def set_enabled(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_enabled()')
 
     def set_background_color(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_background_color()')
 
     def set_on_press(self, handler):
         # No special handling required

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -15,20 +15,20 @@ class TextInput(Widget):
 
     def set_readonly(self, value):
         # self.native.editable = not value
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_readonly()')
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_placeholder()')
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_font()')
 
     def get_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.get_value()')
 
     def set_value(self, value):
         self.native.setText(value)

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -15,20 +15,20 @@ class TextInput(Widget):
 
     def set_readonly(self, value):
         # self.native.editable = not value
-        self.platform.not_implemented('TextInput.set_readonly()')
+        self.interface.factory.not_implemented('TextInput.set_readonly()')
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        self.platform.not_implemented('TextInput.set_placeholder()')
+        self.interface.factory.not_implemented('TextInput.set_placeholder()')
 
     def set_alignment(self, value):
-        self.platform.not_implemented('TextInput.set_alignment()')
+        self.interface.factory.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        self.platform.not_implemented('TextInput.set_font()')
+        self.interface.factory.not_implemented('TextInput.set_font()')
 
     def get_value(self, value):
-        self.platform.not_implemented('TextInput.get_value()')
+        self.interface.factory.not_implemented('TextInput.get_value()')
 
     def set_value(self, value):
         self.native.setText(value)

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -55,19 +55,19 @@ class Window:
         pass
 
     def info_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.save_file_dialog()')

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -55,19 +55,19 @@ class Window:
         pass
 
     def info_dialog(self, title, message):
-        self.platform.not_implemented('Window.info_dialog()')
+        self.interface.factory.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        self.platform.not_implemented('Window.question_dialog()')
+        self.interface.factory.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        self.platform.not_implemented('Window.confirm_dialog()')
+        self.interface.factory.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        self.platform.not_implemented('Window.error_dialog()')
+        self.interface.factory.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        self.platform.not_implemented('Window.stack_trace_dialog()')
+        self.interface.factory.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        self.platform.not_implemented('Window.save_file_dialog()')
+        self.interface.factory.not_implemented('Window.save_file_dialog()')

--- a/src/cocoa/toga_cocoa/factory.py
+++ b/src/cocoa/toga_cocoa/factory.py
@@ -27,7 +27,14 @@ from .widgets.tree import Tree
 from .widgets.webview import WebView
 from .window import Window
 
+
+def not_implemented(feature):
+    print('[GTK backend] Not implemented: {}'.format(feature))
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     'native_color',
     'Command',

--- a/src/cocoa/toga_cocoa/factory.py
+++ b/src/cocoa/toga_cocoa/factory.py
@@ -29,7 +29,7 @@ from .window import Window
 
 
 def not_implemented(feature):
-    print('[GTK backend] Not implemented: {}'.format(feature))
+    print('[Cocoa] Not implemented: {}'.format(feature))
 
 
 __all__ = [

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -35,6 +35,7 @@ class Button(Widget):
         self.native.title = self.interface.label
 
     def set_on_press(self, handler):
+        # No special handling required
         pass
 
     def rehint(self):

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -30,6 +30,7 @@ from .widgets.tree import *
 from .widgets.webview import *
 from .window import Window
 
+
 __all__ = [
     # Applications
     'App', 'MainWindow',

--- a/src/django/toga_django/app.py
+++ b/src/django/toga_django/app.py
@@ -36,10 +36,10 @@ class App(AppInterface):
         pass
 
     def open_document(self, fileURL):
-        self.platform.not_implemented('App.open_document()')
+        self.interface.factory.not_implemented('App.open_document()')
 
     def create_menus(self):
-        self.platform.not_implemented('App.create_menus()')
+        self.interface.factory.not_implemented('App.create_menus()')
 
     # ====
 

--- a/src/django/toga_django/app.py
+++ b/src/django/toga_django/app.py
@@ -36,10 +36,10 @@ class App(AppInterface):
         pass
 
     def open_document(self, fileURL):
-        raise NotImplementedError()
+        self.platform.not_implemented('App.open_document()')
 
     def create_menus(self):
-        raise NotImplementedError()
+        self.platform.not_implemented('App.create_menus()')
 
     # ====
 

--- a/src/django/toga_django/widgets/base.py
+++ b/src/django/toga_django/widgets/base.py
@@ -80,4 +80,4 @@ class Widget:
         pass
 
     def set_font(self, font):
-        self.platform.not_implemented('Widget.set_font()')
+        self.interface.factory.not_implemented('Widget.set_font()')

--- a/src/django/toga_django/widgets/base.py
+++ b/src/django/toga_django/widgets/base.py
@@ -80,4 +80,4 @@ class Widget:
         pass
 
     def set_font(self, font):
-        raise NotImplementedError()
+        self.platform.not_implemented('Widget.set_font()')

--- a/src/django/toga_django/widgets/label.py
+++ b/src/django/toga_django/widgets/label.py
@@ -15,7 +15,7 @@ class Label(Widget):
         self._impl.innerText = self.interface._text
 
     def set_alignment(self, value):
-        self.platform.not_implemented('Label.set_alignment()')
+        self.interface.factory.not_implemented('Label.set_alignment()')
 
     def rehint(self):
         pass

--- a/src/django/toga_django/widgets/label.py
+++ b/src/django/toga_django/widgets/label.py
@@ -15,7 +15,7 @@ class Label(Widget):
         self._impl.innerText = self.interface._text
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Label.set_alignment()')
 
     def rehint(self):
         pass

--- a/src/django/toga_django/widgets/textinput.py
+++ b/src/django/toga_django/widgets/textinput.py
@@ -25,16 +25,16 @@ class TextInput(TextInputInterface, WidgetMixin):
     #         self.window.callbacks[(self.id, 'on_press')] = self.on_press
 
     def set_placeholder(self, value):
-        self.platform.not_implemented('TextInput.set_placeholder()')
+        self.interface.factory.not_implemented('TextInput.set_placeholder()')
 
     def set_readonly(self, value):
-        self.platform.not_implemented('TextInput.set_readonly()')
+        self.interface.factory.not_implemented('TextInput.set_readonly()')
 
     def get_value(self):
         return self._impl.value
 
     def set_value(self, value):
-        self.platform.not_implemented('TextInput.set_value()')
+        self.interface.factory.not_implemented('TextInput.set_value()')
 
     def set_alignment(self, value):
         pass

--- a/src/django/toga_django/widgets/textinput.py
+++ b/src/django/toga_django/widgets/textinput.py
@@ -25,16 +25,16 @@ class TextInput(TextInputInterface, WidgetMixin):
     #         self.window.callbacks[(self.id, 'on_press')] = self.on_press
 
     def set_placeholder(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_placeholder()')
 
     def set_readonly(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_readonly()')
 
     def get_value(self):
         return self._impl.value
 
     def set_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_value()')
 
     def set_alignment(self, value):
         pass

--- a/src/django/toga_django/window.py
+++ b/src/django/toga_django/window.py
@@ -102,19 +102,19 @@ class Window(WindowInterface):
         })
 
     def info_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.save_file_dialog()')

--- a/src/django/toga_django/window.py
+++ b/src/django/toga_django/window.py
@@ -102,19 +102,19 @@ class Window(WindowInterface):
         })
 
     def info_dialog(self, title, message):
-        self.platform.not_implemented('Window.info_dialog()')
+        self.interface.factory.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        self.platform.not_implemented('Window.question_dialog()')
+        self.interface.factory.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        self.platform.not_implemented('Window.confirm_dialog()')
+        self.interface.factory.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        self.platform.not_implemented('Window.error_dialog()')
+        self.interface.factory.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        self.platform.not_implemented('Window.stack_trace_dialog()')
+        self.interface.factory.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        self.platform.not_implemented('Window.save_file_dialog()')
+        self.interface.factory.not_implemented('Window.save_file_dialog()')

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -28,7 +28,15 @@ from .widgets.tree import *
 from .widgets.webview import *
 from .window import Window
 
+
+
+def not_implemented(feature):
+    raise NotImplementedError()
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     'native_color',
     'Command',

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -42,7 +42,7 @@ def error(window, title, message):
 
 
 def stack_trace(window, title, message, content, retry=False):
-    raise NotImplementedError()
+    window.platform.not_implemented('dialogs.stack_trace()')
 
 
 def save_file(window, title, suggested_filename, file_types):

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -27,7 +27,14 @@ from .widgets.tree import Tree
 from .widgets.webview import WebView
 from .window import Window
 
+
+def not_implemented(feature):
+    print('[GTK backend] Not implemented: {}'.format(feature))
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     'native_color',
     'Command',

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -29,7 +29,7 @@ from .window import Window
 
 
 def not_implemented(feature):
-    print('[GTK backend] Not implemented: {}'.format(feature))
+    print('[GTK+] Not implemented: {}'.format(feature))
 
 
 __all__ = [

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -47,7 +47,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        self.platform.not_implemented('Widget.set_hidden()')
+        self.interface.factory.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, fon't can't be changed

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -47,7 +47,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        raise NotImplementedError()
+        self.platform.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, fon't can't be changed

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -18,13 +18,14 @@ class Button(Widget):
 
     def set_enabled(self, value):
         # self._impl.set_sensitive(value)
-        self.platform.not_implemented('Button.set_enabled()')
+        self.interface.factory.not_implemented('Button.set_enabled()')
 
     def set_background_color(self, value):
-        self.platform.not_implemented('Button.set_background_color()')
+        self.interface.factory.not_implemented('Button.set_background_color()')
 
     def set_on_press(self, handler):
-        self.platform.not_implemented('Button.set_on_press()')
+        # No special handling required
+        pass
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -18,13 +18,13 @@ class Button(Widget):
 
     def set_enabled(self, value):
         # self._impl.set_sensitive(value)
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_enabled()')
 
     def set_background_color(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_background_color()')
 
     def set_on_press(self, handler):
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_on_press()')
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -20,22 +20,22 @@ class NumberInput(Widget):
         self.native.editable = not value
 
     def set_step(self, step):
-        self.platform.not_implemented('NumberInput.set_step()')
+        self.interface.factory.not_implemented('NumberInput.set_step()')
 
     def set_min_value(self, value):
-        self.platform.not_implemented('NumberInput.set_min_value()')
+        self.interface.factory.not_implemented('NumberInput.set_min_value()')
 
     def set_max_value(self, value):
-        self.platform.not_implemented('NumberInput.set_max_value()')
+        self.interface.factory.not_implemented('NumberInput.set_max_value()')
 
     def set_value(self, value):
         self.native.set_value(value)
 
     def set_alignment(self, value):
-        self.platform.not_implemented('NumberInput.set_alignment()')
+        self.interface.factory.not_implemented('NumberInput.set_alignment()')
 
     def set_font(self, value):
-        self.platform.not_implemented('NumberInput.set_font()')
+        self.interface.factory.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
         self.interface.style.min_width = self.interface.MIN_WIDTH

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -20,22 +20,22 @@ class NumberInput(Widget):
         self.native.editable = not value
 
     def set_step(self, step):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_step()')
 
     def set_min_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_min_value()')
 
     def set_max_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_max_value()')
 
     def set_value(self, value):
         self.native.set_value(value)
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_alignment()')
 
     def set_font(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
         self.interface.style.min_width = self.interface.MIN_WIDTH

--- a/src/gtk/toga_gtk/widgets/splitcontainer.py
+++ b/src/gtk/toga_gtk/widgets/splitcontainer.py
@@ -40,4 +40,4 @@ class SplitContainer(Widget):
             self.interface.content[1].window = self.interface.window
 
     def set_direction(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('SplitContainer.set_direction()')

--- a/src/gtk/toga_gtk/widgets/splitcontainer.py
+++ b/src/gtk/toga_gtk/widgets/splitcontainer.py
@@ -40,4 +40,4 @@ class SplitContainer(Widget):
             self.interface.content[1].window = self.interface.window
 
     def set_direction(self, value):
-        self.platform.not_implemented('SplitContainer.set_direction()')
+        self.interface.factory.not_implemented('SplitContainer.set_direction()')

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -18,10 +18,10 @@ class TextInput(Widget):
         self.native.set_placeholder_text(value)
 
     def set_alignment(self, value):
-        self.platform.not_implemented('TextInput.set_alignment()')
+        self.interface.factory.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        self.platform.not_implemented('TextInput.set_font()')
+        self.interface.factory.not_implemented('TextInput.set_font()')
 
     def get_value(self):
         return self.native.get_text()

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -18,10 +18,10 @@ class TextInput(Widget):
         self.native.set_placeholder_text(value)
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_font()')
 
     def get_value(self):
         return self.native.get_text()

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -47,17 +47,14 @@ class WebView(Widget):
             self.webview.load_uri(value)
 
     def set_user_agent(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.info_dialog()')
         # self.native.user_agent = value if value else "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.101 Safari/537.36"
 
     def set_content(self, root_url, content):
         self.webview.load_html(content, root_url)
 
-    def set_user_agent(self, value):
-        raise NotImplementedError()
-
     def get_dom(self):
-        raise NotImplementedError()
+        self.platform.not_implemented('WebView.get_dom()')
 
     def evaluate(self, javascript):
         return self.webview.run_javascript(javascript, None, None, None)

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -47,14 +47,14 @@ class WebView(Widget):
             self.webview.load_uri(value)
 
     def set_user_agent(self, value):
-        self.platform.not_implemented('Window.info_dialog()')
+        self.interface.factory.not_implemented('Window.info_dialog()')
         # self.native.user_agent = value if value else "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.101 Safari/537.36"
 
     def set_content(self, root_url, content):
         self.webview.load_html(content, root_url)
 
     def get_dom(self):
-        self.platform.not_implemented('WebView.get_dom()')
+        self.interface.factory.not_implemented('WebView.get_dom()')
 
     def evaluate(self, javascript):
         return self.webview.run_javascript(javascript, None, None, None)

--- a/src/iOS/toga_iOS/factory.py
+++ b/src/iOS/toga_iOS/factory.py
@@ -29,7 +29,7 @@ from .window import Window
 
 
 def not_implemented(feature):
-    print('[iOS backend] Not implemented: {}'.format(feature))
+    print('[iOS] Not implemented: {}'.format(feature))
 
 
 __all__ = [

--- a/src/iOS/toga_iOS/factory.py
+++ b/src/iOS/toga_iOS/factory.py
@@ -27,7 +27,14 @@ from .widgets.textinput import TextInput
 from .widgets.webview import *
 from .window import Window
 
+
+def not_implemented(feature):
+    print('[iOS backend] Not implemented: {}'.format(feature))
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     'native_color',
     # 'Command',

--- a/src/iOS/toga_iOS/widgets/selection.py
+++ b/src/iOS/toga_iOS/widgets/selection.py
@@ -59,7 +59,7 @@ class Selection(Widget):
             self.native.text = item
 
     def select_item(self, item):
-        raise NotImplementedError()
+        self.platform.not_implemented('Selection.select_item()')
 
     def get_selected_item(self):
         return self.interface.items[self.picker.selectedRowInComponent(0)]

--- a/src/iOS/toga_iOS/widgets/selection.py
+++ b/src/iOS/toga_iOS/widgets/selection.py
@@ -59,7 +59,7 @@ class Selection(Widget):
             self.native.text = item
 
     def select_item(self, item):
-        self.platform.not_implemented('Selection.select_item()')
+        self.interface.factory.not_implemented('Selection.select_item()')
 
     def get_selected_item(self):
         return self.interface.items[self.picker.selectedRowInComponent(0)]

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -43,7 +43,7 @@ class WebView(Widget):
 
     def set_user_agent(self, value):
         # self.native.customUserAgent = value if value else "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
-        raise NotImplementedError()
+        self.platform.not_implemented('WebView.set_user_agent()')
 
     def evaluate(self, javascript):
         return self.native.stringByEvaluatingJavaScriptFromString_(javascript)

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -43,7 +43,7 @@ class WebView(Widget):
 
     def set_user_agent(self, value):
         # self.native.customUserAgent = value if value else "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
-        self.platform.not_implemented('WebView.set_user_agent()')
+        self.interface.factory.not_implemented('WebView.set_user_agent()')
 
     def evaluate(self, javascript):
         return self.native.stringByEvaluatingJavaScriptFromString_(javascript)

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -67,19 +67,19 @@ class Window:
         self.interface.content.refresh()
 
     def info_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        raise NotImplementedError()
+        self.platform.not_implemented('Window.save_file_dialog()')

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -67,19 +67,19 @@ class Window:
         self.interface.content.refresh()
 
     def info_dialog(self, title, message):
-        self.platform.not_implemented('Window.info_dialog()')
+        self.interface.factory.not_implemented('Window.info_dialog()')
 
     def question_dialog(self, title, message):
-        self.platform.not_implemented('Window.question_dialog()')
+        self.interface.factory.not_implemented('Window.question_dialog()')
 
     def confirm_dialog(self, title, message):
-        self.platform.not_implemented('Window.confirm_dialog()')
+        self.interface.factory.not_implemented('Window.confirm_dialog()')
 
     def error_dialog(self, title, message):
-        self.platform.not_implemented('Window.error_dialog()')
+        self.interface.factory.not_implemented('Window.error_dialog()')
 
     def stack_trace_dialog(self, title, message, content, retry=False):
-        self.platform.not_implemented('Window.stack_trace_dialog()')
+        self.interface.factory.not_implemented('Window.stack_trace_dialog()')
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        self.platform.not_implemented('Window.save_file_dialog()')
+        self.interface.factory.not_implemented('Window.save_file_dialog()')

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -30,7 +30,7 @@ class App:
         print("STUB: If you want to handle opening documents, implement App.open_document(fileURL)")
 
     def create_menus(self):
-        raise NotImplementedError()
+        self.platform.not_implemented('App.create_menus()')
 
     def run_app(self):
         self.create()
@@ -43,4 +43,4 @@ class App:
         thread.Join()
 
     def exit(self):
-        raise NotImplementedError()
+        self.platform.not_implemented('App.exit()')

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -30,7 +30,7 @@ class App:
         print("STUB: If you want to handle opening documents, implement App.open_document(fileURL)")
 
     def create_menus(self):
-        self.platform.not_implemented('App.create_menus()')
+        self.interface.factory.not_implemented('App.create_menus()')
 
     def run_app(self):
         self.create()
@@ -43,4 +43,4 @@ class App:
         thread.Join()
 
     def exit(self):
-        self.platform.not_implemented('App.exit()')
+        self.interface.factory.not_implemented('App.exit()')

--- a/src/winforms/toga_winforms/dialogs.py
+++ b/src/winforms/toga_winforms/dialogs.py
@@ -20,8 +20,8 @@ def error(window, title, message):
 
 
 def stack_trace(window, title, message, content, retry=False):
-    raise NotImplementedError()
+    window.platform.not_implemented('Dialog.set_enabled()')
 
 
 def save_file(window, title, suggested_filename, file_types):
-    raise NotImplementedError()
+    window.platform.not_implemented('Dialog.set_enabled()')

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -26,7 +26,14 @@ from .widgets.textinput import *
 from .widgets.webview import *
 from .window import Window
 
+
+def not_implemented(feature):
+    print('[Winforms backend] Not implemented: {}'.format(feature))
+
+
 __all__ = [
+    'not_implemented',
+
     'App', 'MainWindow',
     # 'color',
     'Command',

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -28,7 +28,7 @@ from .window import Window
 
 
 def not_implemented(feature):
-    print('[Winforms backend] Not implemented: {}'.format(feature))
+    print('[Winforms] Not implemented: {}'.format(feature))
 
 
 __all__ = [

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -33,7 +33,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        raise NotImplementedException()
+        self.platform.not_implemented('Widget.set_enabled()')
 
     ### APPLICATOR
 
@@ -47,7 +47,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        raise NotImplementedError()
+        self.platform.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -33,7 +33,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        self.platform.not_implemented('Widget.set_enabled()')
+        self.interface.factory.not_implemented('Widget.set_enabled()')
 
     ### APPLICATOR
 
@@ -47,7 +47,7 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        self.platform.not_implemented('Widget.set_hidden()')
+        self.interface.factory.not_implemented('Widget.set_hidden()')
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -32,7 +32,7 @@ class Button(Widget):
         pass
 
     def set_background_color(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('Button.set_background_color()')
 
     def rehint(self):
         # self.native.Size = Size(0, 0)

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -32,7 +32,7 @@ class Button(Widget):
         pass
 
     def set_background_color(self, value):
-        self.platform.not_implemented('Button.set_background_color()')
+        self.interface.factory.not_implemented('Button.set_background_color()')
 
     def rehint(self):
         # self.native.Size = Size(0, 0)

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -16,7 +16,7 @@ class MultilineTextInput(Widget):
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        self.platform.not_implemented('MultilineTextInput.set_placeholder()')
+        self.interface.factory.not_implemented('MultilineTextInput.set_placeholder()')
 
     def set_value(self, value):
         self.native.Text = value

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -16,7 +16,7 @@ class MultilineTextInput(Widget):
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        raise NotImplementedError()
+        self.platform.not_implemented('MultilineTextInput.set_placeholder()')
 
     def set_value(self, value):
         self.native.Text = value

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -8,30 +8,30 @@ class NumberInput(Widget):
         self.native = WinForms.NumericUpDown()
 
     def set_readonly(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_readonly()')
 
     def set_step(self, step):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_step()')
 
     def set_min_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_min_value()')
 
     def set_max_value(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_max_value()')
 
     def set_value(self, value):
         if value is not None and value is not "":
             self.native.Value = ClrDecimal.Parse(value)
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_alignment()')
 
     def set_font(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
         self.interface.intrinsic.width = 120
         self.interface.intrinsic.height = 32
 
     def set_on_change(self, handler):
-        raise NotImplementedError()
+        self.platform.not_implemented('NumberInput.set_on_change()')

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -8,30 +8,30 @@ class NumberInput(Widget):
         self.native = WinForms.NumericUpDown()
 
     def set_readonly(self, value):
-        self.platform.not_implemented('NumberInput.set_readonly()')
+        self.interface.factory.not_implemented('NumberInput.set_readonly()')
 
     def set_step(self, step):
-        self.platform.not_implemented('NumberInput.set_step()')
+        self.interface.factory.not_implemented('NumberInput.set_step()')
 
     def set_min_value(self, value):
-        self.platform.not_implemented('NumberInput.set_min_value()')
+        self.interface.factory.not_implemented('NumberInput.set_min_value()')
 
     def set_max_value(self, value):
-        self.platform.not_implemented('NumberInput.set_max_value()')
+        self.interface.factory.not_implemented('NumberInput.set_max_value()')
 
     def set_value(self, value):
         if value is not None and value is not "":
             self.native.Value = ClrDecimal.Parse(value)
 
     def set_alignment(self, value):
-        self.platform.not_implemented('NumberInput.set_alignment()')
+        self.interface.factory.not_implemented('NumberInput.set_alignment()')
 
     def set_font(self, value):
-        self.platform.not_implemented('NumberInput.set_font()')
+        self.interface.factory.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
         self.interface.intrinsic.width = 120
         self.interface.intrinsic.height = 32
 
     def set_on_change(self, handler):
-        self.platform.not_implemented('NumberInput.set_on_change()')
+        self.interface.factory.not_implemented('NumberInput.set_on_change()')

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -27,4 +27,4 @@ class OptionContainer(Widget):
         self.native.Controls.Add(item)
 
     def set_on_select(self, handler):
-        raise NotImplementedError()
+        self.platform.not_implemented('OptionContainer.set_on_select()')

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -27,4 +27,4 @@ class OptionContainer(Widget):
         self.native.Controls.Add(item)
 
     def set_on_select(self, handler):
-        self.platform.not_implemented('OptionContainer.set_on_select()')
+        self.interface.factory.not_implemented('OptionContainer.set_on_select()')

--- a/src/winforms/toga_winforms/widgets/progressbar.py
+++ b/src/winforms/toga_winforms/widgets/progressbar.py
@@ -11,11 +11,11 @@ class ProgressBar(Widget):
 
     def start(self):
         '''Not supported for WinForms implementation'''
-        raise NotImplementedError()
+        self.platform.not_implemented('ProgressBar.start()')
 
     def stop(self):
         '''Not supported for WinForms implementation'''
-        raise NotImplementedError()
+        self.platform.not_implemented('ProgressBar.stop()')
 
     def set_max(self, value):
         self.native.Maximum = value

--- a/src/winforms/toga_winforms/widgets/progressbar.py
+++ b/src/winforms/toga_winforms/widgets/progressbar.py
@@ -11,11 +11,11 @@ class ProgressBar(Widget):
 
     def start(self):
         '''Not supported for WinForms implementation'''
-        self.platform.not_implemented('ProgressBar.start()')
+        self.interface.factory.not_implemented('ProgressBar.start()')
 
     def stop(self):
         '''Not supported for WinForms implementation'''
-        self.platform.not_implemented('ProgressBar.stop()')
+        self.interface.factory.not_implemented('ProgressBar.stop()')
 
     def set_max(self, value):
         self.native.Maximum = value

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -33,19 +33,19 @@ class Table(Widget):
         self.native.Items.Insert(index, item._impl)
 
     def change(self, item):
-        self.platform.not_implemented('Table.change()')
+        self.interface.factory.not_implemented('Table.change()')
 
     def remove(self, item):
-        self.platform.not_implemented('Table.remove()')
+        self.interface.factory.not_implemented('Table.remove()')
 
     def clear(self):
         self.native.Clear()
 
     def set_on_select(self, handler):
-        self.platform.not_implemented('Table.set_on_select()')
+        self.interface.factory.not_implemented('Table.set_on_select()')
 
     def scroll_to_row(self, row):
-        self.platform.not_implemented('Table.scroll_to_row()')
+        self.interface.factory.not_implemented('Table.scroll_to_row()')
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -33,19 +33,19 @@ class Table(Widget):
         self.native.Items.Insert(index, item._impl)
 
     def change(self, item):
-        raise NotImplementedError()
+        self.platform.not_implemented('Table.change()')
 
     def remove(self, item):
-        raise NotImplementedError()
+        self.platform.not_implemented('Table.remove()')
 
     def clear(self):
         self.native.Clear()
 
     def set_on_select(self, handler):
-        raise NotImplementedError()
+        self.platform.not_implemented('Table.set_on_select()')
 
     def scroll_to_row(self, row):
-        raise NotImplementedError()
+        self.platform.not_implemented('Table.scroll_to_row()')
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -15,7 +15,7 @@ class TextInput(Widget):
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        self.platform.not_implemented('TextInput.set_placeholder()')
+        self.interface.factory.not_implemented('TextInput.set_placeholder()')
 
     def get_value(self):
         return self.native.Text
@@ -24,10 +24,10 @@ class TextInput(Widget):
         self.native.Text = value
 
     def set_alignment(self, value):
-        self.platform.not_implemented('TextInput.set_alignment()')
+        self.interface.factory.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        self.platform.not_implemented('TextInput.set_font()')
+        self.interface.factory.not_implemented('TextInput.set_font()')
 
     def rehint(self):
         # Height of a text input is known and fixed.

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -15,7 +15,7 @@ class TextInput(Widget):
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_placeholder()')
 
     def get_value(self):
         return self.native.Text
@@ -24,10 +24,10 @@ class TextInput(Widget):
         self.native.Text = value
 
     def set_alignment(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_alignment()')
 
     def set_font(self, value):
-        raise NotImplementedError()
+        self.platform.not_implemented('TextInput.set_font()')
 
     def rehint(self):
         # Height of a text input is known and fixed.

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -1,6 +1,5 @@
 from travertino.size import at_least
 
-from toga import not_implemented
 from toga_winforms.libs import *
 
 from .base import Widget
@@ -24,13 +23,13 @@ class WebView(Widget):
         self.native.Navigate(Uri(root_url), "_self" , None, self.interface.user_agent)
 
     def get_dom(self):
-        not_implemented('WebView.get_dom()')
+        self.interface.factory.not_implemented('WebView.get_dom()')
 
     def set_user_agent(self, value):
         self.native.customUserAgent = value if value else "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"
 
     def evaluate(self, javascript):
-        not_implemented('WebView.evaluate()')
+        self.interface.factory.not_implemented('WebView.evaluate()')
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -1,5 +1,6 @@
 from travertino.size import at_least
 
+from toga import not_implemented
 from toga_winforms.libs import *
 
 from .base import Widget
@@ -23,13 +24,13 @@ class WebView(Widget):
         self.native.Navigate(Uri(root_url), "_self" , None, self.interface.user_agent)
 
     def get_dom(self):
-        raise NotImplementedError()
+        not_implemented('WebView.get_dom()')
 
     def set_user_agent(self, value):
         self.native.customUserAgent = value if value else "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"
 
     def evaluate(self, javascript):
-        raise NotImplementedError()
+        not_implemented('WebView.evaluate()')
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)


### PR DESCRIPTION
After the 0.3.0.dev3 release, we've had a couple of reports of crashes where NotImplementedError has been raised for features that have been added. 

This hard error is problematic; if a new feature is added to one platform, it's easy to accidentally break every other platform. 

This patch replaces the exception with a console log - except for the dummy platform, where it *does* raise an exception (since the dummy is a test harness, where silently logging isn't useful)