### PR TITLE
Implement data source `index()` method

### DIFF
--- a/src/core/tests/sources/test_list_source.py
+++ b/src/core/tests/sources/test_list_source.py
@@ -346,3 +346,29 @@ class ListSourceTests(TestCase):
         self.assertEqual(source[1].val2, 333)
 
         listener.remove.assert_called_once_with(item=row)
+
+    def test_get_row_index(self):
+        "You can get the index of any row within a list source"
+
+        source = ListSource(
+            data=[
+                ('first', 111),
+                ('second', 222),
+                ('third', 333),
+            ],
+            accessors=['val1', 'val2']
+        )
+
+        for i, row in enumerate(source):
+            self.assertEqual(i, source.index(row))
+
+        # look-alike rows are not equal, so index lookup should fail
+        with self.assertRaises(ValueError):
+            lookalike_row = Row(val1='second', val2=222)
+            source.index(lookalike_row)
+
+        with self.assertRaises(ValueError):
+            source.index(None)
+
+        with self.assertRaises(ValueError):
+            source.index(Row())

--- a/src/core/tests/sources/test_tree_source.py
+++ b/src/core/tests/sources/test_tree_source.py
@@ -35,7 +35,6 @@ class LeafNodeTests(TestCase):
         self.assertEqual(result, 0)
 
 
-
 class NodeTests(TestCase):
     def setUp(self):
         self.source = Mock()

--- a/src/core/tests/sources/test_tree_source.py
+++ b/src/core/tests/sources/test_tree_source.py
@@ -732,3 +732,39 @@ class TreeSourceTests(TestCase):
         self.assertEqual(source[2][0].val2, -331)
 
         listener.change.assert_called_once_with(item=source[2][0])
+
+    def test_get_node_index(self):
+        "You can get the index of any node within a tree source, relative to its parent"
+
+        source = TreeSource(
+            data={
+                ('first', 111): None,
+                ('second', 222): [],
+                ('third', 333): [
+                    ('third.one', 331),
+                    ('third.two', 332)
+                ]
+            },
+            accessors=['val1', 'val2']
+        )
+
+        for i, node in enumerate(source):
+            self.assertEqual(i, source.index(node))
+
+        # Test indices on deep nodes, too
+        third = source[2]
+        for i, node in enumerate(third):
+            self.assertEqual(i, source.index(node))
+
+        # look-alike nodes are not equal, so index lookup should fail
+        with self.assertRaises(ValueError):
+            lookalike_node = Node(val1='second', val2=222)
+            source.index(lookalike_node)
+
+        # Describe how edge cases are handled
+
+        with self.assertRaises(AttributeError):
+            source.index(None)
+
+        with self.assertRaises(ValueError):
+            source.index(Node())

--- a/src/core/toga/sources/list_source.py
+++ b/src/core/toga/sources/list_source.py
@@ -51,15 +51,9 @@ class ListSource(Source):
 
     def _create_row(self, data):
         if isinstance(data, dict):
-            row = Row(**{
-                name: value
-                for name, value in data.items()
-            })
+            row = Row(**data)
         else:
-            row = Row(**{
-                accessor: value
-                for accessor, value in zip(self._accessors, data)
-            })
+            row = Row(**dict(zip(self._accessors, data)))
         row._source = self
         return row
 
@@ -81,17 +75,11 @@ class ListSource(Source):
 
     def insert(self, index, *values, **named):
         # Coalesce values and data into a single data dictionary,
-        # and use that to create the data row
-        node = self._create_row(dict(
-            named,
-            **{
-                accessor: value
-                for accessor, value in zip(self._accessors, values)
-            }
-        ))
-        self._data.insert(index, node)
-        self._notify('insert', index=index, item=node)
-        return node
+        # and use that to create the data row. Explicitly named data override.
+        row = self._create_row(dict(zip(self._accessors, values), **named))
+        self._data.insert(index, row)
+        self._notify('insert', index=index, item=row)
+        return row
 
     def prepend(self, *values, **named):
         return self.insert(0, *values, **named)
@@ -99,7 +87,7 @@ class ListSource(Source):
     def append(self, *values, **named):
         return self.insert(len(self), *values, **named)
 
-    def remove(self, node):
-        self._data.remove(node)
-        self._notify('remove', item=node)
-        return node
+    def remove(self, row):
+        self._data.remove(row)
+        self._notify('remove', item=row)
+        return row

--- a/src/core/toga/sources/list_source.py
+++ b/src/core/toga/sources/list_source.py
@@ -91,3 +91,6 @@ class ListSource(Source):
         self._data.remove(row)
         self._notify('remove', item=row)
         return row
+
+    def index(self, row):
+        return self._data.index(row)

--- a/src/core/toga/sources/tree_source.py
+++ b/src/core/toga/sources/tree_source.py
@@ -76,10 +76,7 @@ class TreeSource(Source):
         if isinstance(data, dict):
             node = Node(**data)
         else:
-            node = Node(**{
-                accessor: value
-                for accessor, value in zip(self._accessors, data)
-            })
+            node = Node(**dict(zip(self._accessors, data)))
         node._source = self
 
         if children is not None:
@@ -116,13 +113,8 @@ class TreeSource(Source):
         return iter(self._roots)
 
     def insert(self, parent, index, *values, **named):
-        node = self._create_node(dict(
-            named,
-            **{
-                accessor: value
-                for accessor, value in zip(self._accessors, values)
-            }
-        ))
+        node = self._create_node(dict(zip(self._accessors, values), **named))
+
         if parent is None:
             self._roots.insert(index, node)
         else:

--- a/src/core/toga/sources/tree_source.py
+++ b/src/core/toga/sources/tree_source.py
@@ -19,7 +19,6 @@ class Node(Row):
         if self.can_have_children():
             return len(self._children)
         else:
-            
             return 0
 
     def can_have_children(self):
@@ -132,12 +131,12 @@ class TreeSource(Source):
         return self.insert(parent, len(parent or self), *values, **named)
 
     def remove(self, node):
-        self._notify('remove', item=node)
         if node._parent is None:
             self._roots.remove(node)
         else:
             node._parent._children.remove(node)
 
+        self._notify('remove', item=node)
         return node
 
     def index(self, node):


### PR DESCRIPTION
<!-- Describe your changes in detail -->
Changes:

- implement index() for ListSource and TreeSource
- simplify a few list/dict compressions using `dict` constructor

<!--- What problem does this change solve? -->
Use cases:

*Fetching items relative to a given item*
```python
def on_select(table, row, **kw):
    i = table.data.index(row)
    prev_row = table.data[i - 1]
    next_ row= table.data[i + 1]
    print("Adjacent rows: {}, {}".format(prev_row, next_row))
```

*Inserting before/after a given item*
```python
def insert_after(table, new_row, ref_row):
    i = table.data.index(ref_row)
    table.data.insert(i+1, new_row) # i - 1 for insert_before, for example.
```

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
The implementation is based on my discussion with @freakboy3742 on Gitter on Dec. 21 concerning data sources and handler content.

---
As far as documentation goes, the index() methods belong to ListSource and TreeSource, which, at the moment, do not have reference documents of their own. There is a background document on data sources, but that seems like the wrong place to put specific method info. I will create create placeholder reference docs for the data sources when I get the chance.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ ] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
