### PR TITLE
Fix slider and switch widget attribute errors in Gtk+

### DIFF
--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -11,6 +11,7 @@ class SliderApp(toga.App):
         # set up common styls
         label_style = Pack(flex=1, padding_right=24)
         box_style = Pack(direction=ROW, padding=10)
+        slider_style = Pack(flex=1)
 
         self.sliderValueLabel = toga.Label("slide me", style=label_style)
 
@@ -22,32 +23,32 @@ class SliderApp(toga.App):
                     toga.Label("default Slider -- range is 0 to 1",
                         style=label_style),
 
-                    toga.Slider(),
+                    toga.Slider(style=slider_style),
                 ]),
 
                 toga.Box(style=box_style, children=[
                     toga.Label("on a scale of 1 to 10, how easy is GUI with Toga?",
                         style=label_style),
 
-                    toga.Slider(range=(1, 10), default=10),
+                    toga.Slider(range=(1, 10), default=10, style=Pack(width=150)),
                 ]),
 
                 toga.Box(style=box_style, children=[
                     toga.Label("Sliders can be disabled", style=label_style),
 
-                    toga.Slider(enabled=False),
+                    toga.Slider(enabled=False, style=slider_style),
                 ]),
 
                 toga.Box(style=box_style, children=[
                     toga.Label("give a Slider some style!", style=label_style),
 
-                    toga.Slider(style=Pack(padding=16, width=300))
+                    toga.Slider(style=slider_style)
                 ]),
 
                 toga.Box(style=box_style, children=[
                     self.sliderValueLabel,
 
-                    toga.Slider(on_slide=self.my_on_slide, range=(-40, 58)),
+                    toga.Slider(on_slide=self.my_on_slide, range=(-40, 58), style=slider_style),
                 ]),
             ],
             style=Pack(direction=COLUMN, padding=24)

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk
+from travertino.size import at_least
 
 from .base import Widget
 
@@ -32,23 +33,12 @@ class Slider(Widget):
         self.adj.set_upper(range[1])
 
     def rehint(self):
-        hints = {}
+        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
         width = self.native.get_preferred_width()
-        minimum_width = 160
-        natural_width = width[1]
-
         height = self.native.get_preferred_height()
-        minimum_height = height[0]
-        natural_height = height[1]
 
-        if minimum_width > 0:
-            hints['min_width'] = minimum_width
-        if minimum_height > 0:
-            hints['min_height'] = minimum_height
-        if natural_width > 0:
-            hints['width'] = natural_width
-        if natural_height > 0:
-            hints['height'] = natural_height
+        # Set intrinsic width to at least the minimum width
+        self.interface.intrinsic.width = at_least(width[0])
+        # Set intrinsic height to the natural height
+        self.interface.intrinsic.height = height[1]
 
-        if hints:
-            self.interface.style.hint(**hints)

--- a/src/gtk/toga_gtk/widgets/switch.py
+++ b/src/gtk/toga_gtk/widgets/switch.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk
+from travertino.size import at_least
 
 from .base import Widget
 
@@ -37,21 +38,11 @@ class Switch(Widget):
         self.switch.set_active(value)
 
     def rehint(self):
-        hints = {}
+        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
         width = self.native.get_preferred_width()
-        minimum_width = width[0]
-        natural_width = width[1]
-
         height = self.native.get_preferred_height()
-        minimum_height = height[0]
-        natural_height = height[1]
 
-        if minimum_width > 0:
-            hints['min_width'] = minimum_width
-        if minimum_height > 0:
-            hints['min_height'] = minimum_height
-        if natural_height > 0:
-            hints['height'] = natural_height
-
-        if hints:
-            self.interface.style.hint(**hints)
+        # Set intrinsic width to at least the minimum width
+        self.interface.intrinsic.width = at_least(width[0])
+        # Set intrinsic height to the natural height
+        self.interface.intrinsic.height = height[1]


### PR DESCRIPTION
Closes #340. Fixes AttributeErrors in the slider and switch widgets in the rehint methods. Updates the slider example to ensure that Slider widgets are getting a Pack style applied.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
