### PR TITLE
Recommend Installing Pre For Tutorial

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -100,7 +100,7 @@ Running the app
 Before you run the app, you'll need to install toga. Although you *can* install
 toga by just running::
 
-    $ pip install toga
+    $ pip install --pre toga
 
 We strongly suggest that you **don't** do this. We'd suggest creating a `virtual
 environment`_ first, and installing toga in that virtual environment.


### PR DESCRIPTION
Changed pip install in tutorial to use the `--pre` flag per @freakboy3742 in order to solve an issue where the current PyPy doesn't work on OSX High Sierra (`TypeError: 'ObjCInstance' object is not callable`).

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
