### PR TITLE
Fix example cookiecutter template

### DIFF
--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
@@ -13,7 +13,6 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
     def startup(self):
         # Set up main window
         self.main_window = toga.MainWindow(self.name)
-        self.main_window.app = self
 
         # Label to show responses.
         label = toga.Label('Ready.')


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Current cookie cutter template raises a Window is already associated with an App exception.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
