### PR TITLE
Updated Table implementation in Winforms. examples/table almost works

### DIFF
--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -47,7 +47,8 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        self.interface.factory.not_implemented('Widget.set_hidden()')
+        if self.native:
+            self.native.Visibility = not hidden
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -17,17 +17,27 @@ class Table(Widget):
             dataColumn.append(col)
 
         self.native.View = WinForms.View.Details
+        self.native.FullRowSelect = True
+        self.native.Multiselect = self.interface.multiple_select
         self.native.Columns.AddRange(dataColumn)
 
     def change_source(self, source):
-        for row in self.interface.data:
-            row._impl = WinForms.ListViewItem(*[
+        for index, row in enumerate(self.interface.data):
+            row._impl = WinForms.ListViewItem([
+                getattr(row, attr) for attr in self.interface._accessors
+            ])
+            self.native.Items.Insert(index, row._impl)
+
+    def update_data(self):
+        self.native.Items.Clear()
+        for index, row in enumerate(self.interface.data):
+            row._impl = WinForms.ListViewItem([
                 getattr(row, attr) for attr in self.interface._accessors
             ])
             self.native.Items.Insert(index, row._impl)
 
     def insert(self, index, item):
-        item._impl = WinForms.ListViewItem(*[
+        item._impl = WinForms.ListViewItem([
             getattr(item, attr) for attr in self.interface._accessors
         ])
         self.native.Items.Insert(index, item._impl)
@@ -36,15 +46,16 @@ class Table(Widget):
         self.interface.factory.not_implemented('Table.change()')
 
     def remove(self, item):
-        self.interface.factory.not_implemented('Table.remove()')
+        self.update_data()
 
     def clear(self):
-        self.native.Clear()
+        self.native.Items.Clear()
 
     def set_on_select(self, handler):
         self.interface.factory.not_implemented('Table.set_on_select()')
 
     def scroll_to_row(self, row):
+        self.native.EnsureVisible(row)
         self.interface.factory.not_implemented('Table.scroll_to_row()')
 
     def rehint(self):


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

Winforms table implementation updated:

- native.ListViewItem assignment with an asterisk didn't show up, so I deleted the asterisk `(*[])` -> `([])`. Will it break anything?
- `clear() `method updated, so it clears the data but not the column names. Is this implementation correct?
- added `multiple_select` implementation and selection of the full row. 
- added `update_data` method that updates data from the interface.data and is called when '`remove`' method is called.
- implemented `widget.set_hidden()` method.

Now `examples/table` works on Windows. Although the handler is not implemented (I believe it's not implemented for any platform yet, as I couldn't find examples). There are also problems with layout in the example

![table_example](https://user-images.githubusercontent.com/15233243/36250467-efb58d3c-124e-11e8-905e-01af1c358ec4.png)

Refs#155: One step closer to working Tutorial3 on Windows

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
