### PR TITLE
Create canvas without on_draw handler

### DIFF
--- a/examples/canvas/README.rst
+++ b/examples/canvas/README.rst
@@ -1,0 +1,12 @@
+Canvas
+======
+
+Test app for the Canvas widget.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ pip install toga
+    $ python -m canvas

--- a/examples/canvas/canvas/__init__.py
+++ b/examples/canvas/canvas/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/canvas/canvas/__main__.py
+++ b/examples/canvas/canvas/__main__.py
@@ -1,0 +1,4 @@
+from canvas.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -1,0 +1,28 @@
+import toga
+from toga.style import Pack
+
+class ExampleCanvasApp(toga.App):
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(self.name, size=(148, 200))
+
+        canvas = toga.Canvas(style=Pack(flex=1))
+        box = toga.Box(children=[canvas])
+
+        # Add the content on the main window
+        self.main_window.content = box
+
+        # Show the main window
+        self.main_window.show()
+
+        with canvas.stroke():
+            with canvas.closed_path(50, 50):
+                canvas.line_to(100, 100)
+
+
+def main():
+    return ExampleCanvasApp('Canvas', 'org.pybee.widgets.canvas')
+
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/canvas/canvas/resources/README
+++ b/examples/canvas/canvas/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/examples/canvas/setup.py
+++ b/examples/canvas/setup.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+import io
+import re
+
+from setuptools import setup, find_packages
+
+with io.open('./canvas/__init__.py', encoding='utf8') as version_file:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+    if version_match:
+        version = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
+with io.open('README.rst', encoding='utf8') as readme:
+    long_description = readme.read()
+
+
+setup(
+    name='canvas',
+    version=version,
+    description='Test app for the Canvas widget.',
+    long_description=long_description,
+    author='BeeWare Project',
+    author_email='contact@pybee.org',
+    license='BSD license',
+    packages=find_packages(
+        exclude=[
+            'docs', 'tests',
+            'windows', 'macOS', 'linux',
+            'iOS', 'android',
+            'django'
+        ]
+    ),
+    package_data={
+        'canvas': ['resources/*'],
+    },
+    install_package_data=True,
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'License :: OSI Approved :: BSD license',
+    ],
+    install_requires=[
+    ],
+    options={
+        'app': {
+            'formal_name': 'Canvas',
+            'bundle': 'org.pybee.widgets'
+        },
+
+        # Desktop/laptop deployments
+        'macos': {
+            'app_requires': [
+                'toga-cocoa',
+            ]
+        },
+        'linux': {
+            'app_requires': [
+                'toga-gtk',
+            ]
+        },
+        'windows': {
+            'app_requires': [
+                'toga-winforms',
+            ]
+        },
+
+        # Mobile deployments
+        'ios': {
+            'app_requires': [
+                'toga-ios',
+            ]
+        },
+        'android': {
+            'app_requires': [
+                'toga-android',
+            ]
+        },
+
+        # Web deployments
+        'django': {
+            'app_requires': [
+                'toga-django',
+            ]
+        },
+    }
+)

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -49,7 +49,9 @@ class Canvas(Widget):
     @on_draw.setter
     def on_draw(self, handler):
         self._on_draw = handler
-        self._impl.set_on_draw(self._on_draw)
+
+        if self._on_draw:
+            self._impl.set_on_draw(self._on_draw)
 
     # Line Styles
 


### PR DESCRIPTION
When I was initially creating the canvas widget, I tested support for drawing simple things without calling the on_draw handler. But, there seems to be some regressions in this actually working. This PR fixes a TypeError when no on_draw handler parameter is passed, and also adds an example to help ensure that simple canvas calls work in the future and will help with final completion of the cocoa implementation of canvas.

I'm not sure if it is related to the changes to support Pack, but I can't get the canvas to display with this example. It looks like the canvas is getting size allocations ok to me when I uncomment the debug statements in the Pack module. I could use some help or direction on further troubleshooting.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
