### PR TITLE
Update example cookiecutter to support Pack

### DIFF
--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
@@ -1,5 +1,6 @@
 import toga
-from colosseum import CSS
+from toga.style import Pack
+from toga.constants import COLUMN, ROW
 
 
 class Example{{ cookiecutter.widget_name }}App(toga.App):
@@ -15,31 +16,31 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
         self.main_window = toga.MainWindow(self.name)
 
         # Label to show responses.
-        label = toga.Label('Ready.')
+        self.label = toga.Label('Ready.')
 
         widget = toga.{{ cookiecutter.widget_name }}()
 
         # Buttons
-        btn_style = CSS(flex=1)
+        btn_style = Pack(flex=1)
         btn_do_stuff = toga.Button('Do stuff', on_press=self.do_stuff, style=btn_style)
-        btn_clear = toga.Button('Clear', on_press=do_clear, style=btn_style)
+        btn_clear = toga.Button('Clear', on_press=self.do_clear, style=btn_style)
         btn_box = toga.Box(
             children=[
                 btn_do_stuff,
                 btn_clear
             ],
-            style=CSS(flex_direction='row')
+            style=Pack(direction=ROW)
         )
 
         # Outermost box
         outer_box = toga.Box(
-            children=[btn_box, widget, label],
-            style=CSS(
+            children=[btn_box, widget, self.label],
+            style=Pack(
                 flex=1,
-                flex_direction='column',
+                direction=COLUMN,
                 padding=10,
-                min_width=500,
-                min_height=300
+                width=500,
+                height=300
             )
         )
 


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

The example cookiecutter template requires updates to support Travertino / Pack instead of Colosseum / CSS. It also fixes the on_press call for the clear button and NameErrors caused by the labels being undefined.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
