### PR TITLE
Fix AttributeError: Nonetype object has no _impl in Cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -48,9 +48,10 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        for view in self._container._impl.subviews:
-            if child._impl == view:
-                view.setHidden(hidden)
+        if self._container:
+            for view in self._container._impl.subviews:
+                if child._impl == view:
+                    view.setHidden(hidden)
 
     def set_font(self, font):
         pass


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

In Cocoa when running any example I was getting an AttributeError caused by applying a style that then sets the visibility attribute on subviews. These subviews are being search for on a container that does not yet exist. This change checks that the container is not None first.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
