### PR TITLE
Fixed core test errors and gtk implementation for NumberInput

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -1,5 +1,4 @@
 from toga.handlers import wrapped_handler
-from sys import maxsize
 
 from .base import Widget
 
@@ -28,11 +27,6 @@ class NumberInput(Widget):
                  min_value=None, max_value=None, readonly=False, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
         self._value = None
-        # Needed for _impl initialization
-        self._min_value = 0
-        self._max_value = 0
-        self._step = 1
-        
         self._impl = self.factory.NumberInput(interface=self)
 
         self.readonly = readonly
@@ -90,7 +84,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("min_value must be an integer")
         except TypeError:
-            self._min_value = -maxsize - 1
+            self._min_value = None
         self._impl.set_min_value(self._min_value)
 
     @property
@@ -110,7 +104,7 @@ class NumberInput(Widget):
         except ValueError:
             raise ValueError("max_value must be an integer")
         except TypeError:
-            self._max_value = maxsize
+            self._max_value = None
         self._impl.set_max_value(self._max_value)
 
     @property

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -1,3 +1,4 @@
+import sys
 from gi.repository import Gtk
 
 from .base import Widget
@@ -5,9 +6,7 @@ from .base import Widget
 
 class NumberInput(Widget):
     def create(self):
-        self.adjustment = Gtk.Adjustment(0, self.interface.min_value,
-                                    self.interface.max_value,
-                                    self.interface.step, 10, 0)
+        self.adjustment = Gtk.Adjustment()
 
         self.native = Gtk.SpinButton()
         self.native.set_adjustment(self.adjustment)
@@ -24,11 +23,17 @@ class NumberInput(Widget):
         self.native.set_adjustment(self.adjustment)
 
     def set_min_value(self, value):
-        self.adjustment.set_lower(value)
+        if value is None:
+            self.adjustment.set_lower(-sys.maxsize - 1)
+        else:
+            self.adjustment.set_lower(value)
         self.native.set_adjustment(self.adjustment)
 
     def set_max_value(self, value):
-        self.adjustment.set_upper(value)
+        if value is None:
+            self.adjustment.set_upper(sys.maxsize)
+        else:
+            self.adjustment.set_upper(value)
         self.native.set_adjustment(self.adjustment)
 
     def set_value(self, value):


### PR DESCRIPTION
An error is getting encountered in core tests related to NumberInput widget which is basically the max and min values being set to None in case of no input for them which is consistent with the definition of the NumberInput. So to fix this the max and min values are being set to None now in the core package and the gtk implementation has also been made consistent with the interface now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
