### PR TITLE
Fix AttributeError: 'App' object has no attribute 'document_types'

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -33,9 +33,9 @@ class AppDelegate(NSObject):
         for filetype in self.interface.document_types:
             fileTypes.addObject(filetype)
 
-        NSDocumentController.sharedDocumentController().runModalOpenPanel(panel, forTypes=fileTypes)
+        NSDocumentController.sharedDocumentController.runModalOpenPanel(panel, forTypes=fileTypes)
 
-        # print("Untitled File opened?", panel.URLs)
+        print("Untitled File opened?", panel.URLs)
         self.application_openFiles_(None, panel.URLs)
 
         return True

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -17,7 +17,7 @@ class MainWindow(Window):
 class AppDelegate(NSObject):
     @objc_method
     def applicationDidFinishLaunching_(self, notification):
-        self.interface.native.activateIgnoringOtherApps(True)
+        self.native.activateIgnoringOtherApps(True)
 
     @objc_method
     def applicationOpenUntitledFile_(self, sender) -> bool:
@@ -94,7 +94,8 @@ class App:
         self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle.bundlePath))
 
         appDelegate = AppDelegate.alloc().init()
-        appDelegate.interface = self
+        appDelegate.interface = self.interface
+        appDelegate.native = self.native
         self.native.setDelegate_(appDelegate)
 
         app_name = self.interface.name

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -35,7 +35,7 @@ class AppDelegate(NSObject):
 
         NSDocumentController.sharedDocumentController.runModalOpenPanel(panel, forTypes=fileTypes)
 
-        print("Untitled File opened?", panel.URLs)
+        # print("Untitled File opened?", panel.URLs)
         self.application_openFiles_(None, panel.URLs)
 
         return True

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -227,6 +227,7 @@ NSDocument = ObjCClass('NSDocument')
 ######################################################################
 # NSDocumentController.h
 NSDocumentController = ObjCClass('NSDocumentController')
+NSDocumentController.declare_class_property('sharedDocumentController')
 
 ######################################################################
 # NSEvent.h

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -64,6 +64,9 @@ class App:
 
         self.commands = CommandSet(None)
 
+        self.document_types = document_types
+        self._documents = []
+
         self._startup_method = startup
 
         self.default_icon = Icon('tiberius', system=True)
@@ -71,9 +74,6 @@ class App:
         self._main_window = None
 
         self._impl = self.factory.App(interface=self)
-
-        self._impl.document_types = document_types
-        self._documents = []
 
     @property
     def app_id(self):

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -64,9 +64,6 @@ class App:
 
         self.commands = CommandSet(None)
 
-        self.document_types = document_types
-        self._documents = []
-
         self._startup_method = startup
 
         self.default_icon = Icon('tiberius', system=True)
@@ -74,6 +71,9 @@ class App:
         self._main_window = None
 
         self._impl = self.factory.App(interface=self)
+
+        self._impl.document_types = document_types
+        self._documents = []
 
     @property
     def app_id(self):


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

When trying to run podium from source I got the following error:

    File "/~/.virtualenvs/podium/lib/python3.6/site-packages/toga_cocoa/app.py", line 33, in applicationOpenUntitledFile_
        for filetype in self.interface.document_types:
    AttributeError: 'App' object has no attribute 'document_types'

and

    File "/~/.virtualenvs/podium/lib/python3.6/site-packages/toga_cocoa/app.py", line 36, in applicationOpenUntitledFile_
        ObjCInstance(NSDocumentController.sharedDocumentController().runModalOpenPanel(panel, forTypes=fileTypes))
    TypeError: 'ObjCInstance' object is not callable

This fix properly points document_types to the implementation so that it can be accessed across the interface. It also stops calling the type property as a function to access the sharedDocumentContorller.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
