### PR TITLE
toga-iOS: Added missing imports in app.py and the Button widget

### DIFF
--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from rubicon.objc import objc_method
 from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
 
 from .libs import (NSNotificationCenter,

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -44,9 +44,10 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        for view in self._container._impl.subviews:
-            if child._impl == view:
-                view.setHidden(hidden)
+        if self._container:
+            for view in self._container._impl.subviews:
+                if child._impl == view:
+                    view.setHidden(hidden)
 
     def set_font(self, font):
         # By default, font can't be changed

--- a/src/iOS/toga_iOS/widgets/button.py
+++ b/src/iOS/toga_iOS/widgets/button.py
@@ -1,7 +1,13 @@
 from rubicon.objc import objc_method, CGSize, SEL
 from travertino.size import at_least
 
-from toga_iOS.libs import UIColor, UIControlEventTouchDown, UIControlStateDisabled, UIControlStateNormal
+from toga_iOS.libs import (
+    UIButton,
+    UIColor,
+    UIControlEventTouchDown,
+    UIControlStateDisabled,
+    UIControlStateNormal
+)
 
 from .base import Widget
 


### PR DESCRIPTION
Signed-off-by: Moises Aranas <moises.aranas@gmail.com>

This fixes some missing imports:
- objc_method reference being used in toga-iOS's app.py
- UIButton reference in toga-iOS's Button implementation

## PR Checklist:
- [x ] All new features have been tested
- [x] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
