### PR TITLE
docs/ProgressBar: replace Markdown table with RST table

### DIFF
--- a/docs/reference/widgets/progressbar.rst
+++ b/docs/reference/widgets/progressbar.rst
@@ -23,12 +23,14 @@ A progress bar can be in one of four visual states, determined by its ``max`` pr
 Calling the ``start()`` method will make the progress bar enter running mode, and calling ``stop()`` will exit running mode.
 See the table below:
 
-| ``max`` | ``is_running`` | Behavior                |
-|---------|-------------|-------------------------|
-| None    | False       | disabled                |
-| None    | True        | indeterminate (continuous animation).     |
-| number  | False       | show percentage         |
-| number  | True        | show percentage and busy animation  |
+======= ============== ===================================
+``max`` ``is_running`` Behavior
+======= ============== ===================================
+None    False          disabled
+None    True           indeterminate (continuous animation)
+number  False          show percentage
+number  True           show percentage and busy animation
+======= ============== ===================================
 
 If a progress bar is indeterminate, it is communicating that it has no exact percentage to report, but that work is still begin done. It may communicate this by continuously pulsing back and forth, for example.
 

--- a/src/core/toga/widgets/progressbar.py
+++ b/src/core/toga/widgets/progressbar.py
@@ -42,19 +42,39 @@ class ProgressBar(Widget):
 
     @property
     def is_running(self):
+        """
+        Use ``start()`` and ``stop()`` to change the running state.
+
+        Returns:
+            True if this progress bar is running
+            False otherwise
+        """
         return self._is_running
 
     @property
     def is_determinate(self):
+        """
+        Determinate progress bars have a numeric ``max`` value (not None).
+
+        Returns:
+            True if this progress bar is determinate (``max`` is not None)
+            False if ``max`` is None
+        """
         return self.max is not None
 
     def start(self):
+        """
+        Starting this progress bar puts it into running mode.
+        """
         self.enabled = True
         if not self.is_running:
             self._impl.start()
         self._is_running = True
 
     def stop(self):
+        """
+        Stop this progress bar (if not already stopped).
+        """
         self._enabled = bool(self.max)
         if self.is_running:
             self._impl.stop()


### PR DESCRIPTION
Signed-off-by: Drew Meier <darius.montez@gmail.com>

<!--- Describe your changes in detail -->
This PR fixes some docs from #291 and adds several docstrings in core/ProgressBar.
<!--- What problem does this change solve? -->
I initially used a Markdown style table (oops!) in the `progressbar.rst` docs page instead of an RST table, so it did not render correctly. I've cut out the old markdown code and replaced it with RST.

I also added some docstrings to the new progress bar properties and methods.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
