### PR TITLE
[WIP] Convert Canvas Widget to Use a Drawing Stack

### DIFF
--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -12,6 +12,7 @@ class StartApp(toga.App):
 
         self.canvas = toga.Canvas(style=Pack(flex=1))
         box = toga.Box(children=[self.canvas])
+        self.draw_tiberius()
 
         # Add the content on the main window
         self.main_window.content = box

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -10,7 +10,7 @@ class StartApp(toga.App):
         #   Main window of the application with title and size
         self.main_window = toga.MainWindow(self.name, size=(148, 200))
 
-        self.canvas = toga.Canvas(on_draw=self.draw_tiberius, style=Pack(flex=1))
+        self.canvas = toga.Canvas(style=Pack(flex=1))
         box = toga.Box(children=[self.canvas])
 
         # Add the content on the main window
@@ -103,8 +103,8 @@ class StartApp(toga.App):
             self.canvas.fill_style('rgba(149.0, 119, 73, 1)')
             self.canvas.write_text('Tiberius', x, y, font)
 
-    def draw_tiberius(self, canvas, context):
-        self.canvas.set_context(context)
+    def draw_tiberius(self):
+        # self.canvas.set_context('tiberius')
         self.fill_head()
         self.draw_eyes()
         self.draw_horns()

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -18,16 +18,6 @@ class CanvasTests(TestCase):
         self.assertEqual(self.testing_canvas._impl.interface, self.testing_canvas)
         self.assertActionPerformed(self.testing_canvas, 'create Canvas')
 
-    def test_canvas_on_draw(self):
-        self.assertIsNone(self.testing_canvas._on_draw)
-
-        # set a new callback
-        def callback(widget, **extra):
-            return 'called {} with {}'.format(type(widget), extra)
-
-        self.testing_canvas.on_draw = callback
-        self.assertValueSet(self.testing_canvas, 'on_draw', self.testing_canvas.on_draw)
-
     def test_basic_drawing(self):
         def drawing(widget):
             self.testing_canvas.rect(-3, -3, 6, 6)
@@ -170,6 +160,11 @@ class CanvasTests(TestCase):
         self.assertActionPerformedWith(self.testing_canvas, 'arc', x=-10, y=-10, radius=10, startangle=math.pi / 2,
                                        endangle=0, anticlockwise=True)
 
+    def test_remove_arc(self):
+        self.testing_canvas.arc(-10, -10, 10, math.pi / 2, 0, True)
+        self.testing_canvas.arc(-10, -10, 10, math.pi / 2, 0, True, True)
+        self.assertActionPerformedWith(self.testing_canvas, 'arc', x=-10, y=-10, radius=10, startangle=math.pi / 2,
+                                       endangle=0, anticlockwise=True, remove=True)
     def test_ellipse(self):
         self.testing_canvas.ellipse(1, 1, 50, 20, 0, math.pi, 2 * math.pi, False)
         self.assertActionPerformedWith(self.testing_canvas, 'ellipse', x=1, y=1, radiusx=50, radiusy=20, rotation=0,

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -38,9 +38,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.set_context(name))
+            self._impl.delete(lambda: self._impl.set_context(name))
         else:
-            self._impl.append_to_draw_stack(self.set_context(name))
+            self._impl.add(lambda: self._impl.set_context(name))
 
     # Line Styles
 
@@ -54,9 +54,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.line_width(width))
+            self._impl.delete(lambda: self._impl.line_width(width))
         else:
-            self._impl.append_to_draw_stack(self.line_width(width))
+            self._impl.add(lambda: self._impl.line_width(width))
 
     # Fill and Stroke Styles
 
@@ -73,9 +73,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.fill_style(color))
+            self._impl.delete(lambda: self._impl.fill_style(color))
         else:
-            self._impl.append_to_draw_stack(self.fill_style(color))
+            self._impl.add(lambda: self._impl.fill_style(color))
 
     def stroke_style(self, color=None, remove=False):
         """Color to use for lines around shapes
@@ -92,9 +92,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.stroke_style(color))
+            self._impl.delete(lambda: self._impl.stroke_style(color))
         else:
-            self._impl.append_to_draw_stack(self.stroke_style(color))
+            self._impl.add(lambda: self._impl.stroke_style(color))
 
     # Paths
 
@@ -112,13 +112,13 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.move_to(x, y))
+            self._impl.delete(lambda: self._impl.move_to(x, y))
             yield
-            self._impl.remove_from_draw_stack(self.close_path())
+            self._impl.delete(self._impl.close_path)
         else:
-            self._impl.append_to_draw_stack(self.move_to(x, y))
+            self._impl.add(lambda: self._impl.move_to(x, y))
             yield
-            self._impl.append_to_draw_stack(self.close_path())
+            self._impl.add(self._impl.close_path)
 
     def move_to(self, x, y, remove=False):
         """Moves the starting point of a new sub-path to the (x, y) coordinates.
@@ -131,9 +131,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.move_to(x, y))
+            self._impl.delete(lambda: self._impl.move_to(x, y))
         else:
-            self._impl.append_to_draw_stack(self.move_to(x, y))
+            self._impl.add(lambda: self._impl.move_to(x, y))
 
     def line_to(self, x, y, remove=False):
         """Connects the last point with a line.
@@ -149,9 +149,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.line_to(x, y))
+            self._impl.delete(lambda: self._impl.line_to(x, y))
         else:
-            self._impl.append_to_draw_stack(self.line_to(x, y))
+            self._impl.add(lambda: self._impl.line_to(x, y))
 
     def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y, remove=False):
         """Adds a cubic Bézier curve to the path.
@@ -173,9 +173,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
+            self._impl.delete(lambda: self._impl.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
         else:
-            self._impl.append_to_draw_stack(self.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
+            self._impl.add(lambda: self._impl.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
 
     def quadratic_curve_to(self, cpx, cpy, x, y, remove=False):
         """Adds a quadratic Bézier curve to the path.
@@ -195,9 +195,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.quadratic_curve_to(cpx, cpy, x, y))
+            self._impl.delete(lambda: self._impl.quadratic_curve_to(cpx, cpy, x, y))
         else:
-            self._impl.append_to_draw_stack(self.quadratic_curve_to(cpx, cpy, x, y))
+            self._impl.add(lambda: self._impl.quadratic_curve_to(cpx, cpy, x, y))
 
     def arc(self, x, y, radius, startangle=0, endangle=2 * pi, anticlockwise=False, remove=False):
         """Adds an arc to the path.
@@ -221,9 +221,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.arc(x, y, radius, startangle, endangle, anticlockwise))
+            self._impl.delete(lambda: self._impl.arc(x, y, radius, startangle, endangle, anticlockwise))
         else:
-            self._impl.append_to_draw_stack(self.arc(x, y, radius, startangle, endangle, anticlockwise))
+            self._impl.add(lambda: self._impl.arc(x, y, radius, startangle, endangle, anticlockwise))
 
     def ellipse(self, x, y, radiusx, radiusy, rotation=0, startangle=0, endangle=2 * pi,
                 anticlockwise=False, remove=False):
@@ -250,11 +250,11 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(
+            self._impl.delete(
                 self.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise))
         else:
-            self._impl.append_to_draw_stack(
-                self.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise))
+            self._impl.add(
+                lambda: self._impl.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise))
 
     def rect(self, x, y, width, height, remove=False):
         """ Creates a path for a rectangle.
@@ -274,9 +274,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.rect(x, y, width, height))
+            self._impl.delete(lambda: self._impl.rect(x, y, width, height))
         else:
-            self._impl.append_to_draw_stack(self.rect(x, y, width, height))
+            self._impl.add(lambda: self._impl.rect(x, y, width, height))
 
     # Drawing Paths
 
@@ -298,19 +298,19 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.new_path())
+            self._impl.delete(self._impl.new_path)
             yield
             if fill_rule is 'evenodd':
-                self._impl.remove_from_draw_stack(self.fill(fill_rule, preserve))
+                self._impl.delete(lambda: self._impl.fill(fill_rule, preserve))
             else:
-                self._impl.remove_from_draw_stack(self.fill('nonzero', preserve))
+                self._impl.delete(lambda: self._impl.fill('nonzero', preserve))
         else:
-            self._impl.append_to_draw_stack(self.new_path())
+            self._impl.add(self._impl.new_path)
             yield
             if fill_rule is 'evenodd':
-                self._impl.append_to_draw_stack(self.fill(fill_rule, preserve))
+                self._impl.add(lambda: self._impl.fill(fill_rule, preserve))
             else:
-                self._impl.append_to_draw_stack(self.fill('nonzero', preserve))
+                self._impl.add(lambda: self._impl.fill('nonzero', preserve))
 
     @contextmanager
     def stroke(self, remove=False):
@@ -328,10 +328,10 @@ class Canvas(Widget):
         """
         if remove:
             yield
-            self._impl.remove_from_draw_stack(self.stroke())
+            self._impl.delete(self._impl.stroke)
         else:
             yield
-            self._impl.append_to_draw_stack(self.stroke())
+            self._impl.add(self._impl.stroke)
 
     # Transformations
 
@@ -351,9 +351,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.rotate(radians))
+            self._impl.delete(lambda: self._impl.rotate(radians))
         else:
-            self._impl.append_to_draw_stack(self.rotate(radians))
+            self._impl.add(lambda: self._impl.rotate(radians))
 
     def scale(self, sx, sy, remove=False):
         """Adds a scaling transformation to the canvas
@@ -370,9 +370,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.scale(sx, sy))
+            self._impl.delete(lambda: self._impl.scale(sx, sy))
         else:
-            self._impl.append_to_draw_stack(self.scale(sx, sy))
+            self._impl.add(lambda: self._impl.scale(sx, sy))
 
     def translate(self, tx, ty, remove=False):
         """Moves the canvas and its origin
@@ -391,9 +391,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.translate(tx, ty))
+            self._impl.delete(lambda: self._impl.translate(tx, ty))
         else:
-            self._impl.append_to_draw_stack(self.translate(tx, ty))
+            self._impl.add(lambda: self._impl.translate(tx, ty))
 
     def reset_transform(self, remove=False):
         """Reset the current transform by the identity matrix
@@ -409,9 +409,9 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.reset_transform())
+            self._impl.delete(self._impl.reset_transform)
         else:
-            self._impl.append_to_draw_stack(self.reset_transform())
+            self._impl.add(self._impl.reset_transform)
 
     # Text
 
@@ -432,6 +432,6 @@ class Canvas(Widget):
 
         """
         if remove:
-            self._impl.remove_from_draw_stack(self.write_text(text, x, y, font))
+            self._impl.delete(lambda: self.write_text(text, x, y, font))
         else:
-            self._impl.append_to_draw_stack(self.write_text(text, x, y, font))
+            self._impl.add(lambda: self._impl.write_text(text, x, y, font))

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -37,7 +37,10 @@ class Canvas(Widget):
 
 
         """
-        self._impl.set_context(name, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.set_context(name))
+        else:
+            self._impl.append_to_draw_stack(self.set_context(name))
 
     # Line Styles
 
@@ -50,7 +53,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.line_width(width, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.line_width(width))
+        else:
+            self._impl.append_to_draw_stack(self.line_width(width))
 
     # Fill and Stroke Styles
 
@@ -66,7 +72,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.fill_style(color, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.fill_style(color))
+        else:
+            self._impl.append_to_draw_stack(self.fill_style(color))
 
     def stroke_style(self, color=None, remove=False):
         """Color to use for lines around shapes
@@ -82,7 +91,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.stroke_style(color, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.stroke_style(color))
+        else:
+            self._impl.append_to_draw_stack(self.stroke_style(color))
 
     # Paths
 
@@ -99,9 +111,14 @@ class Canvas(Widget):
         Yields: None
 
         """
-        self._impl.move_to(x, y, remove)
-        yield
-        self._impl.close_path(remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.move_to(x, y))
+            yield
+            self._impl.remove_from_draw_stack(self.close_path())
+        else:
+            self._impl.append_to_draw_stack(self.move_to(x, y))
+            yield
+            self._impl.append_to_draw_stack(self.close_path())
 
     def move_to(self, x, y, remove=False):
         """Moves the starting point of a new sub-path to the (x, y) coordinates.
@@ -113,7 +130,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.move_to(x, y, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.move_to(x, y))
+        else:
+            self._impl.append_to_draw_stack(self.move_to(x, y))
 
     def line_to(self, x, y, remove=False):
         """Connects the last point with a line.
@@ -128,7 +148,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.line_to(x, y, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.line_to(x, y))
+        else:
+            self._impl.append_to_draw_stack(self.line_to(x, y))
 
     def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y, remove=False):
         """Adds a cubic Bézier curve to the path.
@@ -149,7 +172,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
+        else:
+            self._impl.append_to_draw_stack(self.bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
 
     def quadratic_curve_to(self, cpx, cpy, x, y, remove=False):
         """Adds a quadratic Bézier curve to the path.
@@ -168,7 +194,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.quadratic_curve_to(cpx, cpy, x, y, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.quadratic_curve_to(cpx, cpy, x, y))
+        else:
+            self._impl.append_to_draw_stack(self.quadratic_curve_to(cpx, cpy, x, y))
 
     def arc(self, x, y, radius, startangle=0, endangle=2 * pi, anticlockwise=False, remove=False):
         """Adds an arc to the path.
@@ -191,7 +220,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.arc(x, y, radius, startangle, endangle, anticlockwise, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.arc(x, y, radius, startangle, endangle, anticlockwise))
+        else:
+            self._impl.append_to_draw_stack(self.arc(x, y, radius, startangle, endangle, anticlockwise))
 
     def ellipse(self, x, y, radiusx, radiusy, rotation=0, startangle=0, endangle=2 * pi,
                 anticlockwise=False, remove=False):
@@ -217,7 +249,12 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(
+                self.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise))
+        else:
+            self._impl.append_to_draw_stack(
+                self.ellipse(x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise))
 
     def rect(self, x, y, width, height, remove=False):
         """ Creates a path for a rectangle.
@@ -236,7 +273,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.rect(x, y, width, height, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.rect(x, y, width, height))
+        else:
+            self._impl.append_to_draw_stack(self.rect(x, y, width, height))
 
     # Drawing Paths
 
@@ -257,12 +297,20 @@ class Canvas(Widget):
         Yields: None
 
         """
-        self._impl.new_path(remove)
-        yield
-        if fill_rule is 'evenodd':
-            self._impl.fill(fill_rule, preserve, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.new_path())
+            yield
+            if fill_rule is 'evenodd':
+                self._impl.remove_from_draw_stack(self.fill(fill_rule, preserve))
+            else:
+                self._impl.remove_from_draw_stack(self.fill('nonzero', preserve))
         else:
-            self._impl.fill('nonzero', preserve, remove)
+            self._impl.append_to_draw_stack(self.new_path())
+            yield
+            if fill_rule is 'evenodd':
+                self._impl.append_to_draw_stack(self.fill(fill_rule, preserve))
+            else:
+                self._impl.append_to_draw_stack(self.fill('nonzero', preserve))
 
     @contextmanager
     def stroke(self, remove=False):
@@ -278,8 +326,12 @@ class Canvas(Widget):
         Yields: None
 
         """
-        yield
-        self._impl.stroke(remove)
+        if remove:
+            yield
+            self._impl.remove_from_draw_stack(self.stroke())
+        else:
+            yield
+            self._impl.append_to_draw_stack(self.stroke())
 
     # Transformations
 
@@ -298,7 +350,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.rotate(radians, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.rotate(radians))
+        else:
+            self._impl.append_to_draw_stack(self.rotate(radians))
 
     def scale(self, sx, sy, remove=False):
         """Adds a scaling transformation to the canvas
@@ -314,7 +369,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.scale(sx, sy, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.scale(sx, sy))
+        else:
+            self._impl.append_to_draw_stack(self.scale(sx, sy))
 
     def translate(self, tx, ty, remove=False):
         """Moves the canvas and its origin
@@ -332,7 +390,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.translate(tx, ty, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.translate(tx, ty))
+        else:
+            self._impl.append_to_draw_stack(self.translate(tx, ty))
 
     def reset_transform(self, remove=False):
         """Reset the current transform by the identity matrix
@@ -347,7 +408,10 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.reset_transform(remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.reset_transform())
+        else:
+            self._impl.append_to_draw_stack(self.reset_transform())
 
     # Text
 
@@ -367,4 +431,7 @@ class Canvas(Widget):
                 stack. Default to False.
 
         """
-        self._impl.write_text(text, x, y, font, remove)
+        if remove:
+            self._impl.remove_from_draw_stack(self.write_text(text, x, y, font))
+        else:
+            self._impl.append_to_draw_stack(self.write_text(text, x, y, font))

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -10,6 +10,15 @@ class Canvas(Widget):
     def set_context(self, context, remove=False):
         self._set_value('context', context, remove)
 
+    def draw_contexts(self, canvas, context):
+        self._action('draw contexts', canvas=canvas, context=context)
+
+    def add(self, draw_command):
+        self._action('add', draw_command=draw_command)
+
+    def delete(self, draw_command):
+        self._action('delete', draw_command=draw_command)
+
     def line_width(self, width=2.0, remove=False):
         self._set_value('line_width', width, remove)
 

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -7,8 +7,8 @@ class Canvas(Widget):
     def create(self):
         self._action('create Canvas')
 
-    def set_context(self, context, remove=False):
-        self._set_value('context', context, remove)
+    def set_context(self, context):
+        self._set_value('context', context)
 
     def draw_contexts(self, canvas, context):
         self._action('draw contexts', canvas=canvas, context=context)
@@ -19,10 +19,10 @@ class Canvas(Widget):
     def delete(self, draw_command):
         self._action('delete', draw_command=draw_command)
 
-    def line_width(self, width=2.0, remove=False):
-        self._set_value('line_width', width, remove)
+    def line_width(self, width=2.0):
+        self._set_value('line_width', width)
 
-    def fill_style(self, color=None, remove=False):
+    def fill_style(self, color=None):
         if color is not None:
             num = re.search('^rgba\((\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*)\)$', color)
             if num is not None:
@@ -31,7 +31,7 @@ class Canvas(Widget):
                 b = num.group(3)
                 a = num.group(4)
                 rgba = str(r + ', ' + g + ', ' + b + ', ' + a)
-                self._set_value('fill_style', rgba, remove)
+                self._set_value('fill_style', rgba)
             else:
                 pass
                 # Support future colosseum versions
@@ -40,68 +40,68 @@ class Canvas(Widget):
                 #         exec('self._set_value('fill_style', color)
         else:
             # set color to black
-            self._set_value('fill_style', '0, 0, 0, 1', remove)
+            self._set_value('fill_style', '0, 0, 0, 1')
 
-    def stroke_style(self, color=None, remove=False):
-        self.fill_style(color, remove)
+    def stroke_style(self, color=None):
+        self.fill_style(color)
 
-    def close_path(self, remove=False):
-        self._action('close path', remove=remove)
+    def close_path(self):
+        self._action('close path')
 
-    def closed_path(self, x, y, remove=False):
-        self._action('closed path', x=x, y=y, remove=remove)
+    def closed_path(self, x, y):
+        self._action('closed path', x=x, y=y)
 
-    def move_to(self, x, y, remove=False):
-        self._action('move to', x=x, y=y, remove=remove)
+    def move_to(self, x, y):
+        self._action('move to', x=x, y=y)
 
-    def line_to(self, x, y, remove=False):
-        self._action('line to', x=x, y=y, remove=remove)
+    def line_to(self, x, y):
+        self._action('line to', x=x, y=y)
 
-    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y, remove=False):
-        self._action('bezier curve to', cp1x=cp1x, cp1y=cp1y, cp2x=cp2x, cp2y=cp2y, x=x, y=y, remove=remove)
+    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y):
+        self._action('bezier curve to', cp1x=cp1x, cp1y=cp1y, cp2x=cp2x, cp2y=cp2y, x=x, y=y)
 
-    def quadratic_curve_to(self, cpx, cpy, x, y, remove=False):
-        self._action('quadratic curve to', cpx=cpx, cpy=cpy, x=x, y=y, remove=remove)
+    def quadratic_curve_to(self, cpx, cpy, x, y):
+        self._action('quadratic curve to', cpx=cpx, cpy=cpy, x=x, y=y)
 
-    def arc(self, x, y, radius, startangle, endangle, anticlockwise, remove=False):
+    def arc(self, x, y, radius, startangle, endangle, anticlockwise):
         self._action('arc', x=x, y=y, radius=radius, startangle=startangle, endangle=endangle,
-                     anticlockwise=anticlockwise, remove=remove)
+                     anticlockwise=anticlockwise)
 
-    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise, remove=False):
+    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise):
         self._action('ellipse', x=x, y=y, radiusx=radiusx, radiusy=radiusy, rotation=rotation, startangle=startangle,
-                     endangle=endangle, anticlockwise=anticlockwise, remove=remove)
+                     endangle=endangle, anticlockwise=anticlockwise)
 
-    def rect(self, x, y, width, height, remove=False):
-        self._action('rect', x=x, y=y, width=width, height=height, remove=remove)
+    def rect(self, x, y, width, height):
+        self._action('rect', x=x, y=y, width=width, height=height)
 
     # Drawing Paths
 
-    def fill(self, fill_rule, preserve, remove=False):
-        self._set_value('fill rule', fill_rule, remove)
+    def fill(self, fill_rule, preserve):
+        self._set_value('fill rule', fill_rule)
         if preserve:
-            self._action('fill preserve', remove=remove)
+            self._action('fill preserve')
         else:
-            self._action('fill', remove=remove)
+            self._action('fill')
 
-    def stroke(self, remove=False):
-        self._action('stroke', remove=remove)
+    def stroke(self):
+        self._action('stroke')
 
     # Transformations
 
-    def rotate(self, radians, remove=False):
-        self._action('rotate', radians=radians, remove=remove)
+    def rotate(self, radians):
+        self._action('rotate', radians=radians)
 
-    def scale(self, sx, sy, remove=False):
-        self._action('scale', sx=sx, sy=sy, remove=remove)
+    def scale(self, sx, sy):
+        self._action('scale', sx=sx, sy=sy)
 
-    def translate(self, tx, ty, remove=False):
-        self._action('translate', tx=tx, ty=ty, remove=remove)
+    def translate(self, tx, ty):
+        self._action('translate', tx=tx, ty=ty)
 
-    def reset_transform(self, remove=False):
+    def reset_transform(self):
         self._action('reset transform')
 
-    def write_text(self, text, x, y, font, remove=False):
-        self._action('write text', text=text, x=x, y=y, font=font, remove=remove)
+    def write_text(self, text, x, y, font):
+        self._action('write text', text=text, x=x, y=y, font=font)
 
     def rehint(self):
         self._action('rehint Canvas')

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -7,16 +7,13 @@ class Canvas(Widget):
     def create(self):
         self._action('create Canvas')
 
-    def set_on_draw(self, handler):
-        self._set_value('on_draw', handler)
+    def set_context(self, context, remove=False):
+        self._set_value('context', context, remove)
 
-    def set_context(self, context):
-        self._set_value('context', context)
+    def line_width(self, width=2.0, remove=False):
+        self._set_value('line_width', width, remove)
 
-    def line_width(self, width=2.0):
-        self._set_value('line_width', width)
-
-    def fill_style(self, color=None):
+    def fill_style(self, color=None, remove=False):
         if color is not None:
             num = re.search('^rgba\((\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*)\)$', color)
             if num is not None:
@@ -25,7 +22,7 @@ class Canvas(Widget):
                 b = num.group(3)
                 a = num.group(4)
                 rgba = str(r + ', ' + g + ', ' + b + ', ' + a)
-                self._set_value('fill_style', rgba)
+                self._set_value('fill_style', rgba, remove)
             else:
                 pass
                 # Support future colosseum versions
@@ -34,66 +31,68 @@ class Canvas(Widget):
                 #         exec('self._set_value('fill_style', color)
         else:
             # set color to black
-            self._set_value('fill_style', '0, 0, 0, 1')
+            self._set_value('fill_style', '0, 0, 0, 1', remove)
 
-    def stroke_style(self, color=None):
-        self.fill_style(color)
+    def stroke_style(self, color=None, remove=False):
+        self.fill_style(color, remove)
 
-    def close_path(self):
-        self._action('close path')
+    def close_path(self, remove=False):
+        self._action('close path', remove=remove)
 
-    def closed_path(self, x, y):
-        self._action('closed path', x=x, y=y)
+    def closed_path(self, x, y, remove=False):
+        self._action('closed path', x=x, y=y, remove=remove)
 
-    def move_to(self, x, y):
-        self._action('move to', x=x, y=y)
+    def move_to(self, x, y, remove=False):
+        self._action('move to', x=x, y=y, remove=remove)
 
-    def line_to(self, x, y):
-        self._action('line to', x=x, y=y)
+    def line_to(self, x, y, remove=False):
+        self._action('line to', x=x, y=y, remove=remove)
 
-    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y):
-        self._action('bezier curve to', cp1x=cp1x, cp1y=cp1y, cp2x=cp2x, cp2y=cp2y, x=x, y=y)
+    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y, remove=False):
+        self._action('bezier curve to', cp1x=cp1x, cp1y=cp1y, cp2x=cp2x, cp2y=cp2y, x=x, y=y, remove=remove)
 
-    def quadratic_curve_to(self, cpx, cpy, x, y):
-        self._action('quadratic curve to', cpx=cpx, cpy=cpy, x=x, y=y)
+    def quadratic_curve_to(self, cpx, cpy, x, y, remove=False):
+        self._action('quadratic curve to', cpx=cpx, cpy=cpy, x=x, y=y, remove=remove)
 
-    def arc(self, x, y, radius, startangle, endangle, anticlockwise):
-        self._action('arc', x=x, y=y, radius=radius, startangle=startangle, endangle=endangle, anticlockwise=anticlockwise)
+    def arc(self, x, y, radius, startangle, endangle, anticlockwise, remove=False):
+        self._action('arc', x=x, y=y, radius=radius, startangle=startangle, endangle=endangle,
+                     anticlockwise=anticlockwise, remove=remove)
 
-    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise):
-        self._action('ellipse', x=x, y=y, radiusx=radiusx, radiusy=radiusy, rotation=rotation, startangle=startangle, endangle=endangle, anticlockwise=anticlockwise)
+    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise, remove=False):
+        self._action('ellipse', x=x, y=y, radiusx=radiusx, radiusy=radiusy, rotation=rotation, startangle=startangle,
+                     endangle=endangle, anticlockwise=anticlockwise, remove=remove)
 
-    def rect(self, x, y, width, height):
-        self._action('rect', x=x, y=y, width=width, height=height)
+    def rect(self, x, y, width, height, remove=False):
+        self._action('rect', x=x, y=y, width=width, height=height, remove=remove)
 
     # Drawing Paths
 
-    def fill(self, fill_rule, preserve):
-        self._set_value('fill rule', fill_rule)
+    def fill(self, fill_rule, preserve, remove=False):
+        self._set_value('fill rule', fill_rule, remove)
         if preserve:
-            self._action('fill preserve')
+            self._action('fill preserve', remove=remove)
         else:
-            self._action('fill')
+            self._action('fill', remove=remove)
 
-    def stroke(self):
-        self._action('stroke')
+    def stroke(self, remove=False):
+        self._action('stroke', remove=remove)
 
     # Transformations
 
-    def rotate(self, radians):
-        self._action('rotate', radians=radians)
+    def rotate(self, radians, remove=False):
+        self._action('rotate', radians=radians, remove=remove)
 
-    def scale(self, sx, sy):
-        self._action('scale', sx=sx, sy=sy)
+    def scale(self, sx, sy, remove=False):
+        self._action('scale', sx=sx, sy=sy, remove=remove)
 
-    def translate(self, tx, ty):
-        self._action('translate', tx=tx, ty=ty)
+    def translate(self, tx, ty, remove=False):
+        self._action('translate', tx=tx, ty=ty, remove=remove)
 
-    def reset_transform(self):
+    def reset_transform(self, remove=False):
         self._action('reset transform')
 
-    def write_text(self, text, x, y, font):
-        self._action('write text', text=text, x=x, y=y, font=font)
+    def write_text(self, text, x, y, font, remove=False):
+        self._action('write text', text=text, x=x, y=y, font=font, remove=remove)
 
     def rehint(self):
         self._action('rehint Canvas')

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -36,33 +36,33 @@ class Canvas(Widget):
         self.native.interface = self.interface
         self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, self.native.get_allocated_width(),
                                      self.native.get_allocated_height())
-        self.context_dict = defaultdict(list)
+        self.context_dict = {}
         self.set_context('default')
-        self.native_context, self.draw_stack = self.context_dict['default']
+        self.draw_stack = self.context_dict['default']
+        print(self.draw_stack)
         self.native.connect('draw', self.draw_all_contexts)
         self.native.font = None
 
-    def set_on_draw(self, handler):
-        self.native.connect('draw', handler)
-
-    def create_context_values(self):
-        self.native_context = cairo.Context(self.surface)
-        draw_stack = []
-        return [self.native_context, draw_stack]
-
-    def draw_all_contexts(self):
-        for context, context_values in self.context_dict.items():
-            self.native_context, draw_stack = context_values
+    def draw_all_contexts(self, canvas, context):
+        print("Start to draw")
+        self.native_context = context
+        print(self.context_dict)
+        for context, draw_stack in self.context_dict.items():
+            print(draw_stack)
             for draw_operation in draw_stack:
                 draw_operation()
+                print("draw op")
 
     def set_context(self, context):
         if context:
             for context in self.context_dict:
+                print("Set context", context)
                 self.draw_stack = self.context_dict[context]
             else:
-                self.context_dict[context] = self.create_context_values()
-                self.native_context, self.draw_stack = self.context_dict[context]
+                print("Create context", context)
+                self.context_dict[context] = []
+                self.draw_stack = self.context_dict[context]
+                print(self.draw_stack)
         else:
             print("No context provided")
 
@@ -85,6 +85,7 @@ class Canvas(Widget):
                     self.draw_stack.remove(self.native_context.set_source_rga(r, g, b, a))
                 else:
                     self.draw_stack.append(self.native_context.set_source_rgba(r, g, b, a))
+                    print("append")
             else:
                 pass
                 # Support future colosseum versions
@@ -103,12 +104,14 @@ class Canvas(Widget):
             self.draw_stack.remove(self.native_context.fill_style(color))
         else:
             self.draw_stack.append(self.native_context.fill_style(color))
+            print("append")
 
     def new_path(self, remove=False):
         if remove:
             self.draw_stack.remove(self.native_context.new_path())
         else:
             self.draw_stack.append(self.native_context.new_path())
+            print("append")
 
     def close_path(self, remove=False):
         if remove:
@@ -117,10 +120,11 @@ class Canvas(Widget):
             self.draw_stack.append(self.native_context.close_path())
 
     def move_to(self, x, y, remove=False):
-        if remove:
-            self.draw_stack.remove(self.native_context.move_to(x, y))
-        else:
-            self.draw_stack.append(self.native_context.move_to(x, y))
+        # if remove:
+        #     self.draw_stack.remove(self.native_context.move_to(x, y))
+        # else:
+            # self.draw_stack.append(self.native_context.move_to(x, y))
+        self.native_context.move_to(x, y)
 
     def line_to(self, x, y, remove=False):
         if remove:

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -33,21 +33,37 @@ class Canvas(Widget):
 
         self.native = Gtk.DrawingArea()
         self.native.interface = self.interface
-        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, self.native.get_allocated_width(),
+        self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, self.native.get_allocated_width(),
                                      self.native.get_allocated_height())
-        self.native.context = cairo.Context(surface)
+        default_stack = []
+        self.current_context = default_stack
+        self.context_map = {'default': default_stack}
+        self.current_context.append(cairo.Context(self.surface))
         self.native.font = None
 
     def set_on_draw(self, handler):
         self.native.connect('draw', handler)
 
     def set_context(self, context):
-        self.native.context = context
+        if context:
+            for context in self.context_map:
+                self.current_context = self.context_map[context]
+            else:
+                self.context_map[context] = []
+                self.current_context = self.context_map[context]
+                self.current_context.append(cairo.Context(self.surface))
+        else:
+            print("No context provided")
 
-    def line_width(self, width=2.0):
-        self.native.context.set_line_width(width)
+    def line_width(self, width=2.0, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.set_line_width(width))
+        else:
+            self.current_context.append(context.set_line_width(width))
 
-    def fill_style(self, color=None):
+    def fill_style(self, color=None, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
         if color is not None:
             num = re.search('^rgba\((\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*), (\d*\.?\d*)\)$', color)
             if num is not None:
@@ -56,7 +72,10 @@ class Canvas(Widget):
                 g = float(num.group(2)) / 255
                 b = float(num.group(3)) / 255
                 a = float(num.group(4))
-                self.native.context.set_source_rgba(r, g, b, a)
+                if remove:
+                    self.current_context.remove(context.set_source_rga(r, g, b, a))
+                else:
+                    self.current_context.append(context.set_source_rgba(r, g, b, a))
             else:
                 pass
                 # Support future colosseum versions
@@ -64,82 +83,166 @@ class Canvas(Widget):
                 #     if named_color == color:
                 #         exec('self.native.set_source_' + str(rgb))
         else:
-            # set color to black
-            self.native.context.set_source_rgba(0, 0, 0, 1)
+            # Default to black
+            if remove:
+                self.current_context.remove(context.set_source_rga(0, 0, 0, 1))
+            else:
+                self.current_context.append(context.set_source_rgba(0, 0, 0, 1))
 
-    def stroke_style(self, color=None):
-        self.fill_style(color)
-
-    def new_path(self):
-        self.native.context.new_path()
-
-    def close_path(self):
-        self.native.context.close_path()
-
-    def move_to(self, x, y):
-        self.native.context.move_to(x, y)
-
-    def line_to(self, x, y):
-        self.native.context.line_to(x, y)
-
-    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y):
-        self.native.context.curve_to(cp1x, cp1y, cp2x, cp2y, x, y)
-
-    def quadratic_curve_to(self, cpx, cpy, x, y):
-        self.native.context.curve_to(cpx, cpy, cpx, cpy, x, y)
-
-    def arc(self, x, y, radius, startangle, endangle, anticlockwise):
-        if anticlockwise:
-            self.native.context.arc_negative(x, y, radius, startangle, endangle)
+    def stroke_style(self, color=None, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.fill_style(color))
         else:
-            self.native.context.arc(x, y, radius, startangle, endangle)
+            self.current_context.append(context.fill_style(color))
 
-    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise):
-        self.native.context.save()
-        self.translate(x, y)
-        if radiusx >= radiusy:
-            self.scale(1, radiusy / radiusx)
-            self.arc(0, 0, radiusx, startangle, endangle, anticlockwise)
-        elif radiusy > radiusx:
-            self.scale(radiusx / radiusy, 1)
-            self.arc(0, 0, radiusy, startangle, endangle, anticlockwise)
-        self.rotate(rotation)
-        self.reset_transform()
-        self.native.context.restore()
+    def new_path(self, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.new_path())
+        else:
+            self.current_context.append(context.new_path())
 
-    def rect(self, x, y, width, height):
-        self.native.context.rectangle(x, y, width, height)
+    def close_path(self, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.close_path())
+        else:
+            self.current_context.append(context.close_path())
+
+    def move_to(self, x, y, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.move_to(x, y))
+        else:
+            self.current_context.append(context.move_to(x, y))
+
+    def line_to(self, x, y, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.line_to(x, y))
+        else:
+            self.current_context.append(context.line_to(x, y))
+
+    def bezier_curve_to(self, cp1x, cp1y, cp2x, cp2y, x, y, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
+        else:
+            self.current_context.append(context.curve_to(cp1x, cp1y, cp2x, cp2y, x, y))
+
+    def quadratic_curve_to(self, cpx, cpy, x, y, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.curve_to(cpx, cpy, cpx, cpy, x, y))
+        else:
+            self.current_context.append(context.curve_to(cpx, cpy, cpx, cpy, x, y))
+
+    def arc(self, x, y, radius, startangle, endangle, anticlockwise, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if anticlockwise and remove:
+            self.current_context.remove(context.arc_negative(x, y, radius, startangle, endangle))
+        elif anticlockwise:
+            self.current_context.append(context.arc_negative(x, y, radius, startangle, endangle))
+        elif remove:
+            self.current_context.remove(context.arc(x, y, radius, startangle, endangle))
+        else:
+            self.current_context.append(context.arc(x, y, radius, startangle, endangle))
+
+    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.save())
+            self.translate(x, y, remove=True)
+            if radiusx >= radiusy:
+                self.scale(1, radiusy / radiusx, remove=True)
+                self.arc(0, 0, radiusx, startangle, endangle, anticlockwise, remove=True)
+            elif radiusy > radiusx:
+                self.scale(radiusx / radiusy, 1, remove=True)
+                self.arc(0, 0, radiusy, startangle, endangle, anticlockwise, remove=True)
+            self.rotate(rotation, remove=True)
+            self.reset_transform(remove=True)
+            self.current_context.remove(context.restore())
+        else:
+            self.current_context.remove(context.save())
+            self.translate(x, y)
+            if radiusx >= radiusy:
+                self.scale(1, radiusy / radiusx)
+                self.arc(0, 0, radiusx, startangle, endangle, anticlockwise)
+            elif radiusy > radiusx:
+                self.scale(radiusx / radiusy, 1)
+                self.arc(0, 0, radiusy, startangle, endangle, anticlockwise)
+            self.rotate(rotation)
+            self.reset_transform()
+            self.current_context.restore()
+
+    def rect(self, x, y, width, height, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.rectangle(x, y, width, height))
+        else:
+            self.current_context.append(context.rectangle(x, y, width, height))
 
     # Drawing Paths
 
-    def fill(self, fill_rule, preserve):
-        if fill_rule is 'evenodd':
-            self.native.context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
+    def fill(self, fill_rule, preserve, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if fill_rule is 'evenodd' and remove:
+            self.current_context.remove(context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD))
+        elif fill_rule is 'evenodd':
+            self.current_context.append(context.set_fill_rule(cairo.FILL_RULE_EVEN_ODD))
+        elif remove:
+            self.current_context.remove(context.set_fill_rule(cairo.FILL_RULE_WINDING))
         else:
-            self.native.context.set_fill_rule(cairo.FILL_RULE_WINDING)
-        if preserve:
-            self.native.context.fill_preserve()
+            self.current_context.append(context.set_fill_rule(cairo.FILL_RULE_WINDING))
+        if preserve and remove:
+            self.current_context.remove(context.fill_preserve())
+        elif preserve:
+            self.current_context.append(context.fill_preserve())
+        elif remove:
+            self.current_context.remove(context.fill())
         else:
-            self.native.context.fill()
+            self.current_context.append(context.fill())
 
-    def stroke(self):
-        self.native.context.stroke()
+    def stroke(self, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.stroke())
+        else:
+            self.current_context.append(context.stroke())
 
     # Transformations
 
-    def rotate(self, radians):
-        self.native.context.rotate(radians)
+    def rotate(self, radians, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.rotate(radians))
+        else:
+            self.current_context.append(context.rotate(radians))
 
-    def scale(self, sx, sy):
-        self.native.context.scale(sx, sy)
+    def scale(self, sx, sy, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.scale(sx, sy))
+        else:
+            self.current_context.append(context.scale(sx, sy))
 
-    def translate(self, tx, ty):
-        self.native.context.translate(tx, ty)
+    def translate(self, tx, ty, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.translate(tx, ty))
+        else:
+            self.current_context.append(context.translate(tx, ty))
 
-    def reset_transform(self):
-        self.native.context.identity_matrix()
+    def reset_transform(self, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
+        if remove:
+            self.current_context.remove(context.identity_matrix())
+        else:
+            self.current_context.append(context.identity_matrix())
 
-    def write_text(self, text, x, y, font):
+    def write_text(self, text, x, y, font, remove=False):
+        context = self.current_context[cairo.Context(self.surface)]
         # Set font family and size
         if font:
             write_font = font
@@ -147,26 +250,37 @@ class Canvas(Widget):
             write_font = self.native.font
             write_font.family = self.native.font.get_family()
             write_font.size = self.native.font.get_size() / SCALE
-        self.native.context.select_font_face(write_font.family)
-        self.native.context.set_font_size(write_font.size)
+        else:
+            return
+        if remove:
+            self.current_context.remove(context.select_font_face(write_font.family))
+            self.current_context.remove(context.set_font_size(write_font.size))
+        else:
+            self.current_context.append(context.select_font_face(write_font.family))
+            self.current_context.append(context.set_font_size(write_font.size))
 
         # Support writing multiline text
         for line in text.splitlines():
             width, height = write_font.measure(line)
-            self.native.context.move_to(x, y)
-            self.native.context.text_path(line)
+            if remove:
+                self.current_context.remove(context.move_to(x, y))
+                self.current_context.remove(context.text_path(line))
+            else:
+                self.current_context.append(context.move_to(x, y))
+                self.current_context.append(context.text_path(line))
             y += height
 
     def measure_text(self, text, font):
+        context = self.current_context[cairo.Context(self.surface)]
         # Set font family and size
         if font:
-            self.native.context.select_font_face(font.family)
-            self.native.context.set_font_size(font.size)
+            self.context.select_font_face(font.family)
+            self.context.set_font_size(font.size)
         elif self.native.font:
-            self.native.context.select_font_face(self.native.font.get_family())
-            self.native.context.set_font_size(self.native.font.get_size() / SCALE)
+            self.context.select_font_face(self.native.font.get_family())
+            self.context.set_font_size(self.native.font.get_size() / SCALE)
 
-        x_bearing, y_bearing, width, height, x_advance, y_advance = self.native.context.text_extents(text)
+        x_bearing, y_bearing, width, height, x_advance, y_advance = self.current_context.text_extents(text)
         return width, height
 
     def rehint(self):


### PR DESCRIPTION
In #319 we discussed that it was desired to remove the callbacks created by using an on_draw handler, and instead push drawing commands to a stack to be drawn with.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct

Questions:
The stack (called "draw_commands") is stored in the implementation right now, but the determination of whether to add or delete from the stack is made on the interface. I didn't like my initial attempt with everything on the implementation, since there was a lot of repetition in methods. But do you think it is better to keep the interface more clean? I would really appreciate any feedback in this area.

Current status: the canvas widget is working properly and draws to the screen, but all tests are broken

[ ] Fix tests
[ ] Further testing with other contexts besides the default one