### PR TITLE
 Modified NumberInput to use Decimals.

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
@@ -6,6 +8,9 @@ from .base import Widget
 class NumberInput(Widget):
     """ A `NumberInput` widget specifies a fixed range of possible numbers.
     The user has two buttons to increment/decrement the value by a step size.
+    Step, min and max can be integers, floats, or Decimals; They can also be specified
+    as strings, which will be converted to Decimals internally. The value of the
+    widget will be evaluated as a Decimal.
 
     Args:
         id (str): An identifier for this widget.
@@ -14,9 +19,9 @@ class NumberInput(Widget):
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
 
-        step (int): Step size of the adjustment buttons.
-        min_value (int): The minimum bound for the widget's value.
-        max_value (int): The maximum bound for the widget's value.
+        step (number): Step size of the adjustment buttons.
+        min_value (number): The minimum bound for the widget's value.
+        max_value (number): The maximum bound for the widget's value.
         readonly (bool):  Whether a user can write/change the number input, defaults to `False`.
         on_change (``callable``): The handler to invoke when the value changes.
         **ex:
@@ -27,6 +32,7 @@ class NumberInput(Widget):
                  min_value=None, max_value=None, readonly=False, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
         self._value = None
+        self._on_change = None
         self._impl = self.factory.NumberInput(interface=self)
 
         self.readonly = readonly
@@ -62,9 +68,9 @@ class NumberInput(Widget):
     @step.setter
     def step(self, step):
         try:
-            self._step = int(step)
+            self._step = Decimal(step)
         except (ValueError, TypeError):
-            raise ValueError("step must be an integer")
+            raise ValueError("step must be an number")
         self._impl.set_step(self._step)
 
     @property
@@ -80,9 +86,9 @@ class NumberInput(Widget):
     @min_value.setter
     def min_value(self, value):
         try:
-            self._min_value = int(value)
+            self._min_value = Decimal(value)
         except ValueError:
-            raise ValueError("min_value must be an integer")
+            raise ValueError("min_value must be a number")
         except TypeError:
             self._min_value = None
         self._impl.set_min_value(self._min_value)
@@ -100,9 +106,9 @@ class NumberInput(Widget):
     @max_value.setter
     def max_value(self, value):
         try:
-            self._max_value = int(value)
+            self._max_value = Decimal(value)
         except ValueError:
-            raise ValueError("max_value must be an integer")
+            raise ValueError("max_value must be a number")
         except TypeError:
             self._max_value = None
         self._impl.set_max_value(self._max_value)
@@ -120,16 +126,17 @@ class NumberInput(Widget):
     @value.setter
     def value(self, value):
         try:
-            self._value = int(value)
+            self._value = Decimal(value)
+
+            if self.min_value is not None and self._value < self.min_value:
+                self._value = self.min_value
+            elif self.max_value is not None and self._value > self.max_value:
+                self._value = self.max_value
         except ValueError:
-            raise ValueError("value must be an integer")
+            raise ValueError("value must be a number")
         except TypeError:
             self._value = None
 
-        if self.min_value is not None and value < self.min_value:
-            self._value = self.min_value
-        elif self.max_value is not None and value > self.max_value:
-            self._value = self.max_value
         self._impl.set_value(value)
 
     @property

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from toga.handlers import wrapped_handler
 
@@ -69,7 +69,7 @@ class NumberInput(Widget):
     def step(self, step):
         try:
             self._step = Decimal(step)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, InvalidOperation):
             raise ValueError("step must be an number")
         self._impl.set_step(self._step)
 
@@ -87,7 +87,7 @@ class NumberInput(Widget):
     def min_value(self, value):
         try:
             self._min_value = Decimal(value)
-        except ValueError:
+        except (ValueError, InvalidOperation):
             raise ValueError("min_value must be a number")
         except TypeError:
             self._min_value = None
@@ -107,7 +107,7 @@ class NumberInput(Widget):
     def max_value(self, value):
         try:
             self._max_value = Decimal(value)
-        except ValueError:
+        except (ValueError, InvalidOperation):
             raise ValueError("max_value must be a number")
         except TypeError:
             self._max_value = None
@@ -132,7 +132,7 @@ class NumberInput(Widget):
                 self._value = self.min_value
             elif self.max_value is not None and self._value > self.max_value:
                 self._value = self.max_value
-        except ValueError:
+        except (ValueError, InvalidOperation):
             raise ValueError("value must be a number")
         except TypeError:
             self._value = None

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -1,4 +1,8 @@
 import sys
+from decimal import Decimal
+
+from travertino.size import at_least
+
 from gi.repository import Gtk
 
 from .base import Widget
@@ -9,35 +13,43 @@ class NumberInput(Widget):
         self.adjustment = Gtk.Adjustment()
 
         self.native = Gtk.SpinButton()
+        self.native.interface = self.interface
         self.native.set_adjustment(self.adjustment)
         self.native.set_numeric(True)
-        self.native.interface = self.interface
+
+        self.native.connect("value-changed", self._on_change)
 
         self.rehint()
+
+    def _on_change(self, widget):
+        self.interface._value = Decimal(self.native.get_value()).quantize(self.interface.step)
+        if self.interface.on_change:
+            self.interface.on_change(widget)
 
     def set_readonly(self, value):
         self.native.editable = not value
 
     def set_step(self, step):
-        self.adjustment.set_step_increment(step)
+        self.adjustment.set_step_increment(float(self.interface.step))
         self.native.set_adjustment(self.adjustment)
+        self.native.set_digits(abs(self.interface.step.as_tuple().exponent))
 
     def set_min_value(self, value):
-        if value is None:
+        if self.interface.min_value is None:
             self.adjustment.set_lower(-sys.maxsize - 1)
         else:
-            self.adjustment.set_lower(value)
+            self.adjustment.set_lower(float(self.interface.min_value))
         self.native.set_adjustment(self.adjustment)
 
     def set_max_value(self, value):
-        if value is None:
+        if self.interface.max_value is None:
             self.adjustment.set_upper(sys.maxsize)
         else:
-            self.adjustment.set_upper(value)
+            self.adjustment.set_upper(float(self.interface.max_value))
         self.native.set_adjustment(self.adjustment)
 
     def set_value(self, value):
-        self.native.set_value(value)
+        self.native.set_value(self.interface.value)
 
     def set_alignment(self, value):
         self.interface.factory.not_implemented('NumberInput.set_alignment()')
@@ -46,8 +58,11 @@ class NumberInput(Widget):
         self.interface.factory.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
-        self.interface.style.min_width = self.interface.MIN_WIDTH
-        self.interface.style.height = 32
+        width = self.native.get_preferred_width()
+        height = self.native.get_preferred_height()
+        if width and height:
+            self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+            self.interface.intrinsic.height = height[1]
 
     def set_on_change(self, handler):
         # No special handling required.

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -1,3 +1,5 @@
+from travertino.size import at_least
+
 from gi.repository import Gtk
 
 from .base import Widget
@@ -34,8 +36,11 @@ class Selection(Widget):
         return self.native.get_active_text()
 
     def rehint(self):
-        self.interface.style.min_width = 90
-        self.interface.style.height = 32
+        width = self.native.get_preferred_width()
+        height = self.native.get_preferred_height()
+
+        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        self.interface.intrinsic.height = height[1]
 
     def set_on_select(self, handler):
         # No special handling required

--- a/src/iOS/toga_iOS/widgets/numberinput.py
+++ b/src/iOS/toga_iOS/widgets/numberinput.py
@@ -1,4 +1,6 @@
 from ctypes import c_int
+from decimal import Decimal
+
 from rubicon.objc import objc_method, CGSize, NSObject, SEL, NSRange, send_message
 from travertino.size import at_least
 

--- a/src/iOS/toga_iOS/widgets/numberinput.py
+++ b/src/iOS/toga_iOS/widgets/numberinput.py
@@ -3,10 +3,10 @@ from rubicon.objc import objc_method, CGSize, NSObject, SEL, NSRange, send_messa
 from travertino.size import at_least
 
 from toga_iOS.libs import(
-    NSTextAlignment, 
-    UIControlEventEditingChanged, 
-    UIKeyboardType, 
-    UITextBorderStyle, 
+    NSTextAlignment,
+    UIControlEventEditingChanged,
+    UIKeyboardType,
+    UITextBorderStyle,
     UITextField
 )
 
@@ -16,6 +16,7 @@ from .base import Widget
 class TogaNumericTextField(UITextField):
     @objc_method
     def textFieldDidChange_(self, notification) -> None:
+        self.interface._value = Decimal(self.text).quantize(self.interface.step)
         if self.interface.on_change:
             self.interface.on_change(self.interface)
 
@@ -25,7 +26,7 @@ class TogaNumericTextField(UITextField):
         # otherwise, accept any number, or '.' (as long as this is the first one)
         if (len(chars) == 0
                     or chars.isdigit()
-                    or (chars == '.' and '.' not in self.interface.value)
+                    or (chars == '.' and '.' not in self.text)
                 ):
             return True
         return False


### PR DESCRIPTION
Number inputs are much more useful if they can handle floating point values, not just integers; but integers have a precision problem. This change allows Numberinputs to use any numeric value (including string versions of numbers) as their min/max/step/value, and preserves the precision of the step value.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct