### PR TITLE
Update optional extras in README to install pygobject using pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,26 +40,34 @@ Minimum requirements
   that ships starting with Ubuntu 14.04 and Fedora 20. You also need to install
   the Python 3 bindings to GTK+.
 
-* We're working on Windows support, but not all features and widgets are supported. At a minimum, you'll need Python 3 and .NET Framework 4. This has been tested on Windows 10, but should work on 7 and 8. Pull requests, help and corrections are most welcome.
+* We're working on Windows support, but not all features and widgets are
+  supported. At a minimum, you'll need Python 3 and .NET Framework 4. This has
+  been tested on Windows 10, but should work on 7 and 8. Pull requests, help and
+  corrections are most welcome.
 
-Optional extras
-^^^^^^^^^^^^^^^
+Optional extras for Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to use the WebView widget, you'll
-also need to have WebKit, plus the GI bindings to WebKit installed. This means
-you'll need to install the following:
+In Linux, extra packages are needed if you want to:
+1. Use the WebView widget
+2. Use Toga inside a `Virtual Environment`_
 
-* **Ubuntu 14.04** ``apt-get install python3-gi gir1.2-webkit-3.0``
+* **Ubuntu / Debian** ``sudo apt-get install python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-webkit2-4.0 libgirepository1.0-dev``
+  Note: for Ubuntu 14.04 install ``gir1.2-webkit-3.0`` instead of ``gir1.2-webkit-4.0``
 
-* **Ubuntu 16.04 / Debian 8** ``apt-get install python3-gi gir1.2-webkit2-4.0``
-  or ``apt-get install python3-gi gir1.2-webkit-3.0``
-  
-* **Fedora** ``dnf install python3-gobject pywebkitgtk``
-  or ``yum install python3-gobject pywebkitgtk`` 
-  
-* **Arch Linux** ``pacman -S python-gobject webkit2gtk`` 
- 
-Other distros should be similar, but feel free to send a pull request with updated dependencies if needed.
+* **Fedora** ``sudo dnf install pygobject3 python3-gobject pywebkitgtk python3-cairo-devel cairo-gobject-devel gobject-introspection-devel``
+  or ``sudo yum install pygobject3 python3-gobject pywebkitgtk python3-cairo-devel cairo-gobject-devel gobject-introspection-devel``
+
+* **Arch Linux** ``sudo pacman -S python-gobject webkit2gtk gobject-introspection``
+
+Other distros should be similar, but feel free to send a pull request with
+updated dependencies if needed.
+
+If you are going to use Toga inside a `Virtual Environment`_, you need to
+install pycairo and pygobject (in that order) in the virtualenv first::
+
+    $ pip install pycairo
+    $ pip install pygobject
 
 If these requirements aren't met, Toga either won't work at all, or won't have
 full functionality.
@@ -91,10 +99,11 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 Contributing
 ~~~~~~~~~~~~
 
-If you'd like to contribute to Toga development, our `guide for first time contributors`_ will help you get started.
+If you'd like to contribute to Toga development, our `guide for first time
+contributors`_ will help you get started.
 
-If you experience problems with Toga, `log them on GitHub`_. If you
-want to contribute code, please `fork the code`_ and `submit a pull request`_.
+If you experience problems with Toga, `log them on GitHub`_. If you want to
+contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
 .. _Read The Docs: https://toga.readthedocs.io
@@ -104,3 +113,4 @@ want to contribute code, please `fork the code`_ and `submit a pull request`_.
 .. _log them on Github: https://github.com/pybee/toga/issues
 .. _fork the code: https://github.com/pybee/toga
 .. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _Virtual Environment: https://www.virtualenv.org


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

This PR is related to issue #371 and PR #374. That PR removes the workaround that links the virtualenv libraries to the system libraries for PyGObject. This README update documents the extra dependencies and other info needed to successfully pip install PyGObject.

I have tested these dependencies on the 3 platform. I also posted my [Vagrant files](https://github.com/danyeaw/vagrant-dev-toga) if anyone is interested in looking at what was installed or testing it themselves.

I also cleaned up some of the other parts of the README to stay at 80 lines.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
