### PR TITLE
Fix toga-cocoa imageview (bypass rehint)

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/imageview.py
+++ b/src/cocoa/toga_cocoa/widgets/imageview.py
@@ -58,8 +58,5 @@ class ImageView(Widget):
             self.native.image = NSImage.alloc().initWithSize(NSSize(width, height))
 
     def rehint(self):
-        self.interface.style.hint(
-            height=self.native.fittingSize().height,
-            width=self.native.fittingSize().width
-        )
+        pass
 


### PR DESCRIPTION
Imageview in toga-cocoa was broken with the following error:
```
  File "easy_weather/.venv/lib/python3.6/site-packages/toga_cocoa/widgets/imageview.py", line 61, in rehint
    self.interface.style.hint(
AttributeError: 'Pack' object has no attribute 'hint'
```

This change just passes the rehint method of the imageview class for toga-cocoa

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested <-Working
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

I realize there might be a better fix, but this seems to work without any known side effects. A working imageview seems better than a broken one...