### PR TITLE
Table selection issue 401

### DIFF
--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -44,3 +44,6 @@ class TableTests(TestCase):
         data_source = CustomSource()
         self.table.data = data_source
         self.assertIs(self.table.data, data_source)
+
+    def test_nothing_selected(self):
+        self.assertEqual(self.table.selection.heading_1, None)

--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -46,4 +46,4 @@ class TableTests(TestCase):
         self.assertIs(self.table.data, data_source)
 
     def test_nothing_selected(self):
-        self.assertEqual(self.table.selection.heading_1, None)
+        self.assertEqual(self.table.selection, None)

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -47,6 +47,7 @@ class Table(Widget):
         self._accessors = build_accessors(headings, accessors)
         self._multiple_select = multiple_select
         self._on_select = None
+        self._selection = None
         self._data = None
 
         self._impl = self.factory.Table(interface=self)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I'm altering toga.widgets.Table so it initialises the ._selection attribute. 
<!--- What problem does this change solve? -->

In #401 I noticed if a user hasn't made a selection in a table, but you check the Tables selection a AttributeError is thrown. The documentation says None should be returned.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
