### PR TITLE
Updated Gtk font implementation

### DIFF
--- a/src/gtk/tests/test_font.py
+++ b/src/gtk/tests/test_font.py
@@ -1,0 +1,72 @@
+import toga
+from toga.constants import MONOSPACE, ITALIC, SMALL_CAPS, BOLD
+import unittest
+import gi
+
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk, Gdk
+except ImportError:
+    import sys
+    # If we're on Linux, Gtk *should* be available. If it isn't, make
+    # Gtk an object... but in such a way that every test will fail,
+    # because the object isn't actually the Gtk interface.
+    if sys.platform == 'linux':
+        Gtk = object()
+    else:
+        Gtk = None
+
+try:
+    gi.require_version("Pango", "1.0")
+    from gi.repository import Pango
+except ImportError:
+    Pango = None
+
+
+@unittest.skipIf(Pango is None, 'Pango import error')
+@unittest.skipIf(Gtk is None,
+                 "Can't run GTK implementation tests on a non-Linux platform")
+class TestFontImplementation(unittest.TestCase):
+    def setUp(self):
+        self.font_choices = {
+            'family': MONOSPACE,
+            'size': 22,
+            'style': ITALIC,
+            'variant': SMALL_CAPS,
+            'weight': BOLD
+        }
+
+        self.font = toga.Font(
+            family=self.font_choices['family'],
+            size=self.font_choices['size'],
+            style=self.font_choices['style'],
+            variant=self.font_choices['variant'],
+            weight=self.font_choices['weight'])
+
+        self.pango_font = self.font._impl.native
+
+        self.font_desc_str = self.pango_font.to_string().lower().split(' ')
+
+    def tearDown(self):
+        self.pango_font.free()
+
+    def test_font_size(self):
+        # int to str
+        self.assertIn(str(self.font_choices['size']), self.font_desc_str)
+
+    def test_font_family(self):
+        self.assertIn(self.font_choices['family'], self.font_desc_str)
+
+    def test_font_style(self):
+        self.assertIn(self.font_choices['style'], self.font_desc_str)
+
+    def test_font_variant(self):
+        self.assertIn(self.font_choices['variant'], self.font_desc_str)
+
+    def test_font_weight(self):
+        self.assertIn(self.font_choices['weight'], self.font_desc_str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/gtk/toga_gtk/font.py
+++ b/src/gtk/toga_gtk/font.py
@@ -9,13 +9,13 @@ try:
 except ImportError:
     Pango = None
 
-
 _FONT_CACHE = {}
 
 
 class Measure(Gtk.Widget):
     """Gtk.Widget for Font.measure in order to create a Pango Layout
     """
+
     def create(self):
         pass
 
@@ -32,7 +32,9 @@ class Font:
         try:
             font = _FONT_CACHE[self.interface]
         except KeyError:
-            font = Pango.FontDescription.from_string('{font.family} {font.size}'.format(font=self.interface))
+            font = Pango.FontDescription.from_string(
+                '{font.family} {font.style} {font.variant} {font.weight} {font.size}'.
+                format(font=self.interface))
             _FONT_CACHE[font] = font
 
         self.native = font


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Pango's font for Gtk+ backend now includes style, variant and weight. 
<!--- What problem does this change solve? -->
Earlier only font family and size were possible
Also added some whitespace :innocent: 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
