### PR TITLE
Properly traverse back to the App object for selecting menu items on cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -70,7 +70,7 @@ class AppDelegate(NSObject):
 
     @objc_method
     def selectMenuItem_(self, sender) -> None:
-        cmd = self.interface._menu_items[sender]
+        cmd = self.interface._impl._menu_items[sender]
         if cmd.action:
             cmd.action(None)
 


### PR DESCRIPTION
Properly call back to the `App` object to get access to `_menu_items` to run menu commands.

Fixes #409 

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
