### PR TITLE
Fixed missing checkmarks for support for Label, TextInput on Android

### DIFF
--- a/docs/reference/supported_platforms/Label.rst
+++ b/docs/reference/supported_platforms/Label.rst
@@ -7,7 +7,7 @@
     +---------+-----+--------+----+------+-----+-----+-------+
     |Component| iOS |winforms|web |django|cocoa| gtk |android|
     +=========+=====+========+====+======+=====+=====+=======+
-    |Label    ||yes|||yes|   ||no|||no|  ||yes|||yes|||no|   |
+    |Label    ||yes|||yes|   ||no|||no|  ||yes|||yes|||yes|   |
     +---------+-----+--------+----+------+-----+-----+-------+
 
 .. |yes| image:: /_static/yes.png

--- a/docs/reference/supported_platforms/TextInput.rst
+++ b/docs/reference/supported_platforms/TextInput.rst
@@ -7,7 +7,7 @@
     +---------+-----+--------+----+------+-----+-----+-------+
     |Component| iOS |winforms|web |django|cocoa| gtk |android|
     +=========+=====+========+====+======+=====+=====+=======+
-    |TextInput||yes|||yes|   ||no|||yes| ||yes|||yes|||no|   |
+    |TextInput||yes|||yes|   ||no|||yes| ||yes|||yes|||yes|   |
     +---------+-----+--------+----+------+-----+-----+-------+
 
 .. |yes| image:: /_static/yes.png


### PR DESCRIPTION
For the supported_platforms record files for Label and TextInput, I changed the file contents that read `no` for the `android` column to `yes`, as these widgets are supported on android.

This solves #420 for the widgets Label and TextInput on android.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
