### PR TITLE
Show secondary window on Winforms

### DIFF
--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -94,6 +94,8 @@ class Window:
             int(self.interface.content.layout.height) + TITLEBAR_HEIGHT
         )
         self.interface.content.refresh()
+        if self.interface is not self.interface.app._main_window:
+            self.native.Show()
 
     def on_close(self):
         pass


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The issue of secondary window not showing up on Windows came up on gitter. Due to the difference in app/ window handling on different platforms, non-main window didn't show up. So, I added a check if the window is main/secondary, and a call to show the native window if it's not main.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
