### PR TITLE
toga-iOS: Removed relative paths in setup.py for examples

### DIFF
--- a/examples/imageview/setup.py
+++ b/examples/imageview/setup.py
@@ -68,8 +68,7 @@ setup(
         # Mobile deployments
         'ios': {
             'app_requires': [
-                '../../src/core',
-                '../../src/iOS',
+                'toga-ios',
             ]
         },
         'android': {

--- a/examples/scrollcontainer/setup.py
+++ b/examples/scrollcontainer/setup.py
@@ -68,8 +68,7 @@ setup(
         # Mobile deployments
         'ios': {
             'app_requires': [
-                '../../src/core',
-                '../../src/iOS',
+                'toga-ios',
             ]
         },
         'android': {

--- a/examples/switch/setup.py
+++ b/examples/switch/setup.py
@@ -51,8 +51,7 @@ setup(
         },
         'ios': {
             'app_requires': [
-                '../../src/core',
-                '../../src/iOS',
+                'toga-ios',
             ]
         },
     }


### PR DESCRIPTION
Cleanup - This removes the relative paths in setup.py for the examples

Signed-off-by: Moises Aranas <moises.aranas@gmail.com>

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
