### PR TITLE
Increased coverage of NumberInput

### DIFF
--- a/src/core/tests/widgets/test_numberinput.py
+++ b/src/core/tests/widgets/test_numberinput.py
@@ -42,6 +42,10 @@ class NumberInputTests(TestCase):
         self.nr_input.min_value = 0
         self.nr_input.max_value = 5
 
+        new_value = None
+        self.nr_input.value = new_value
+        self.assertEqual(self.nr_input.value, new_value)
+
         new_value = []
         with self.assertRaises(ValueError):
             self.nr_input.value = new_value


### PR DESCRIPTION
NumberInput tests did not cover the statements where NumberInput.value gets assign to None when a TypeError occurs. This PR does so and now the NumberInput coverage is 100%.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
