### PR TITLE
Increased coverage for ProgressBar and implemented Window.set_full_screen in Gtk

### DIFF
--- a/src/core/tests/widgets/test_progressbar.py
+++ b/src/core/tests/widgets/test_progressbar.py
@@ -73,18 +73,18 @@ class ProgressBarTests(TestCase):
     def test_set_value_to_number_less_than_max(self):
         new_value = self.progress_bar.max / 2
         self.progress_bar.value = new_value
-        self.assertEqual(self.progress_bar._value, new_value)
+        self.assertEqual(self.progress_bar.value, new_value)
         self.assertValueSet(self.progress_bar, 'value', value=new_value)
 
     def test_set_value_to_number_greater_than_max(self):
         new_value = self.progress_bar.max + 1
         self.progress_bar.value = new_value
-        self.assertEqual(self.progress_bar._value, self.progress_bar.max)
+        self.assertEqual(self.progress_bar.value, self.progress_bar.max)
         self.assertValueSet(self.progress_bar, 'value', value=new_value)
 
     def test_set_value_to_none(self):
         self.progress_bar.value = None
-        self.assertEqual(self.progress_bar._value, 0)  # 0 is clean value for None
+        self.assertEqual(self.progress_bar.value, 0)  # 0 is clean value for None
         self.assertValueSet(self.progress_bar, 'value', value=None)
 
     def test_disabled_cases(self):

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -119,6 +119,12 @@ class Window:
     def set_size(self, size):
         pass
 
+    def set_full_screen(self, is_full_screen):
+        if is_full_screen:
+            self.native.fullscreen()
+        else:
+            self.native.unfullscreen()
+
     def info_dialog(self, title, message):
         return dialogs.info(self.interface, title, message)
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
There is no function for `set_full_screen` in any of the backends but the function is being used in the core module. To solve this, I have implemented the `set_full_screen()` for the Gtk module as a start.

I have also increased the coverage of ProgressBar by using `self.progress_bar.value` instead of `self.progress_bar._value` in all the assert statements since ideally the former one should be used to access the value attribute of the progress bar. This, in turn, has also increased the coverage of Progress Bar as well.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
