### PR TITLE
Implemented info, question, confirm and error dialog

### DIFF
--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -123,19 +123,23 @@ class Window:
             self.interface.content.refresh()
 
     def info_dialog(self, title, message):
-        pass
+        return WinForms.MessageBox.Show(message, title, WinForms.MessageBoxButtons.OK)
 
     def question_dialog(self, title, message):
-        pass
+        result = WinForms.MessageBox.Show(message, title, WinForms.MessageBoxButtons.YesNo)
+        return result
 
     def confirm_dialog(self, title, message):
-        pass
+        result = WinForms.MessageBox.Show(message, title, WinForms.MessageBoxButtons.OKCancel)
+        # this returns 1 (DialogResult.OK enum) for OK and 2 for Cancel
+        return True if result == WinForms.DialogResult.OK else False
 
     def error_dialog(self, title, message):
-        pass
+        return WinForms.MessageBox.Show(message, title, WinForms.MessageBoxButtons.OK,
+                                        WinForms.MessageBoxIcon.Error)
 
     def stack_trace_dialog(self, title, message, content, retry=False):
         pass
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        pass
+        self.interface.factory.not_implemented('Window.save_file_dialog()')


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

<!--- Describe your changes in detail -->
The dialogs are implemented. I tested them using the demo app without the tree. Error dialog even has the native windows error sound :)
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
