### PR TITLE
Edit Box vertical shift calculations if it's outermost widget

### DIFF
--- a/src/winforms/toga_winforms/widgets/box.py
+++ b/src/winforms/toga_winforms/widgets/box.py
@@ -10,9 +10,14 @@ class Box(Widget):
 
     def set_bounds(self, x, y, width, height):
         if self.native:
-            vertical_shift = self.interface.style.padding_top
+            vertical_shift = 0
+            try:
+                # If the box is the outer widget, we need to shift it to the frame vertical_shift
+                vertical_shift = self.frame.vertical_shift - self.interface.style.padding_top
+            except AttributeError:
+                vertical_shift = self.interface.style.padding_top
             horizontal_shift = self.interface.style.padding_left
             horizontal_size_adjustment = self.interface.style.padding_right + horizontal_shift
-            vertical_size_adjustment = self.interface.style.padding_bottom + vertical_shift
+            vertical_size_adjustment = self.interface.style.padding_bottom
             self.native.Size = Size(width + horizontal_size_adjustment, height + vertical_size_adjustment)
-            self.native.Location = Point(x - horizontal_shift, y - vertical_shift)
+            self.native.Location = Point(x - horizontal_shift, y + vertical_shift)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -36,16 +36,16 @@ class Window:
         self.toolbar_items = None
 
     def create_toolbar(self):
-        self.toolbar_native = WinForms.MenuStrip()
+        self.toolbar_native = WinForms.ToolStrip()
         for cmd in self.interface.toolbar:
             if cmd == GROUP_BREAK:
                 item = WinForms.ToolStripSeparator()
             elif cmd == SECTION_BREAK:
                 item = WinForms.ToolStripSeparator()
             else:
-                cmd.native = cmd.bind(self.interface.factory)
-                native_icon = cmd.icon.bind(self.interface.factory).native
+                cmd.bind(self.interface.factory)
                 if cmd.icon is not None:
+                    native_icon = cmd.icon.bind(self.interface.factory).native
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.label)


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

<!--- Describe your changes in detail -->
When a box is the outer-most container, vertical shift of the frame (window, in this case), should be added to the box layout. 
Also, the error raised when a toolbar item didn't have an icon, is handled in this PR.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
