### PR TITLE
Add open file dialog and example app for dialogs

### DIFF
--- a/examples/dialogs/README.rst
+++ b/examples/dialogs/README.rst
@@ -1,0 +1,12 @@
+Dialogs
+=======
+
+Test app for the Dialog in Main Window.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ pip install toga
+    $ python -m dialogs

--- a/examples/dialogs/dialogs/__init__.py
+++ b/examples/dialogs/dialogs/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/dialogs/dialogs/__main__.py
+++ b/examples/dialogs/dialogs/__main__.py
@@ -1,0 +1,4 @@
+from dialogs.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -24,7 +24,6 @@ class ExampledialogsApp(toga.App):
         fname = self.main_window.open_file_dialog(
             title="Open file with Toga",
         )
-        print('FNAME: ', fname)
         if fname is not None:
             self.label.text = "File to open:" + fname
         else:
@@ -36,7 +35,7 @@ class ExampledialogsApp(toga.App):
             "Save file with Toga",
             suggested_filename=fname)
         if save_path is not None:
-            self.label.text = "File saved:" + fname
+            self.label.text = "File saved with Toga:" + fname
         else:
             self.label.text = "Save file dialog was canceled"
 

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -24,9 +24,9 @@ class ExampledialogsApp(toga.App):
         fname = self.main_window.open_file_dialog(
             title="Open file with Toga",
         )
-        if fname is not None:
+        try:
             self.label.text = "File to open:" + fname
-        else:
+        except ValueError:
             self.label.text = "Open file dialog was canceled"
 
     def action_save_file_dialog(self, widget):

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -29,6 +29,15 @@ class ExampledialogsApp(toga.App):
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 
+    def action_select_folder_dialog(self, widget):
+        path_name = self.main_window.select_folder_dialog(
+            title="Select folder with Toga",
+        )
+        try:
+            self.label.text = "Folder selected:" + path_name
+        except ValueError:
+            self.label.text = "Folder select dialog was canceled"
+
     def action_save_file_dialog(self, widget):
         fname = 'Toga_file.txt'
         save_path = self.main_window.save_file_dialog(
@@ -44,7 +53,7 @@ class ExampledialogsApp(toga.App):
         self.main_window = toga.MainWindow(title=self.name)
 
         # Label to show responses.
-        self.label = toga.Label('Ready.')
+        self.label = toga.Label('Ready.', style=Pack(padding_top=20))
 
         # Buttons
         btn_style = Pack(flex=1)
@@ -52,12 +61,14 @@ class ExampledialogsApp(toga.App):
         btn_question = toga.Button('Question', on_press=self.action_question_dialog, style=btn_style)
         btn_open = toga.Button('Open File', on_press=self.action_open_file_dialog, style=btn_style)
         btn_save = toga.Button('Save File', on_press=self.action_save_file_dialog, style=btn_style)
+        btn_select = toga.Button('Select Folder', on_press=self.action_select_folder_dialog, style=btn_style)
         dialog_btn_box = toga.Box(
             children=[
                 btn_info,
                 btn_question,
                 btn_open,
-                btn_save
+                btn_save,
+                btn_select
             ],
             style=Pack(direction=ROW)
         )
@@ -79,9 +90,7 @@ class ExampledialogsApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
-                width=500,
-                height=300
+                padding=10
             )
         )
 

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -1,0 +1,102 @@
+import toga
+from toga.constants import COLUMN, ROW
+from toga.style import Pack
+
+
+class ExampledialogsApp(toga.App):
+    # Button callback functions
+    def do_stuff(self, widget, **kwargs):
+        self.label.text = "Do stuff."
+
+    def do_clear(self, widget, **kwargs):
+        self.label.text = "Ready."
+
+    def action_info_dialog(self, widget):
+        self.main_window.info_dialog('Toga', 'THIS! IS! TOGA!!')
+
+    def action_question_dialog(self, widget):
+        if self.main_window.question_dialog('Toga', 'Is this cool or what?'):
+            self.main_window.info_dialog('Happiness', 'I know, right! :-)')
+        else:
+            self.main_window.info_dialog('Shucks...', "Well aren't you a spoilsport... :-(")
+
+    def action_open_file_dialog(self, widget):
+        fname = self.main_window.open_file_dialog(
+            title="Open file with Toga",
+        )
+        print('FNAME: ', fname)
+        if fname is not None:
+            self.label.text = "File to open:" + fname
+        else:
+            self.label.text = "Open file dialog was canceled"
+
+    def action_save_file_dialog(self, widget):
+        fname = 'Toga_file.txt'
+        save_path = self.main_window.save_file_dialog(
+            "Save file with Toga",
+            suggested_filename=fname)
+        if save_path is not None:
+            self.label.text = "File saved:" + fname
+        else:
+            self.label.text = "Save file dialog was canceled"
+
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(title=self.name)
+
+        # Label to show responses.
+        self.label = toga.Label('Ready.')
+
+        # Buttons
+        btn_style = Pack(flex=1)
+        btn_info = toga.Button('Info', on_press=self.action_info_dialog, style=btn_style)
+        btn_question = toga.Button('Question', on_press=self.action_question_dialog, style=btn_style)
+        btn_open = toga.Button('Open File', on_press=self.action_open_file_dialog, style=btn_style)
+        btn_save = toga.Button('Save File', on_press=self.action_save_file_dialog, style=btn_style)
+        dialog_btn_box = toga.Box(
+            children=[
+                btn_info,
+                btn_question,
+                btn_open,
+                btn_save
+            ],
+            style=Pack(direction=ROW)
+        )
+        # Dialog Buttons
+        btn_style = Pack(flex=1)
+        btn_do_stuff = toga.Button('Do stuff', on_press=self.do_stuff, style=btn_style)
+        btn_clear = toga.Button('Clear', on_press=self.do_clear, style=btn_style)
+        btn_box = toga.Box(
+            children=[
+                btn_do_stuff,
+                btn_clear
+            ],
+            style=Pack(direction=ROW)
+        )
+
+        # Outermost box
+        outer_box = toga.Box(
+            children=[btn_box, dialog_btn_box, self.label],
+            style=Pack(
+                flex=1,
+                direction=COLUMN,
+                padding=10,
+                width=500,
+                height=300
+            )
+        )
+
+        # Add the content on the main window
+        self.main_window.content = outer_box
+
+        # Show the main window
+        self.main_window.show()
+
+
+def main():
+    return ExampledialogsApp('Dialogs', 'org.pybee.widgets.dialogs')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/dialogs/dialogs/resources/README
+++ b/examples/dialogs/dialogs/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/examples/dialogs/setup.py
+++ b/examples/dialogs/setup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import io
+import re
+
+from setuptools import setup, find_packages
+
+with io.open('./dialogs/__init__.py', encoding='utf8') as version_file:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+    if version_match:
+        version = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+with io.open('README.rst', encoding='utf8') as readme:
+    long_description = readme.read()
+
+setup(
+    name='dialogs',
+    version=version,
+    description='Test app for the Dialogs widget.',
+    long_description=long_description,
+    author='BeeWare Project',
+    author_email='contact@pybee.org',
+    license='BSD license',
+    packages=find_packages(
+        exclude=[
+            'docs', 'tests',
+            'windows', 'macOS', 'linux',
+            'iOS', 'android',
+            'django'
+        ]
+    ),
+    package_data={
+        'dialogs': ['resources/*'],
+    },
+    install_package_data=True,
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'License :: OSI Approved :: BSD license',
+    ],
+    install_requires=[
+    ],
+    options={
+        'app': {
+            'formal_name': 'Dialogs',
+            'bundle': 'org.pybee.widgets'
+        },
+
+        # Desktop/laptop deployments
+        'macos': {
+            'app_requires': [
+                'toga-cocoa',
+            ]
+        },
+        'linux': {
+            'app_requires': [
+                'toga-gtk',
+            ]
+        },
+        'windows': {
+            'app_requires': [
+                'toga-winforms',
+            ]
+        },
+
+        # Mobile deployments
+        'ios': {
+            'app_requires': [
+                'toga-ios',
+            ]
+        },
+        'android': {
+            'app_requires': [
+                'toga-android',
+            ]
+        },
+
+        # Web deployments
+        'django': {
+            'app_requires': [
+                'toga-django',
+            ]
+        },
+    }
+)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -257,3 +257,19 @@ class Window:
             The absolute path(str) to the selected location.
         """
         return self._impl.save_file_dialog(title, suggested_filename, file_types)
+
+
+def open_file_dialog(self, title, initial_directory=None, file_types=None):
+    """ This opens a native dialog where the user can select the file to open.
+    It is possible to set the initial folder and and only show files with specified file extensions.
+
+    Args:
+        title (str): The title of the dialog window.
+        initial_directory(str): Initial folder displayed in the dialog.
+        file_types: A list of strings with the allowed file extensions.
+
+    Returns:
+        The absolute path(str) to the selected file or None
+    """
+    # Should we allow multiselect?
+    return self._impl.save_file_dialog(title, initial_directory, file_types)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -247,6 +247,7 @@ class Window:
     def save_file_dialog(self, title, suggested_filename, file_types=None):
         """ This opens a native dialog where the user can select a place to save a file.
         It is possible to suggest a filename and force the user to use a specific file extension.
+        If no path is returned (eg. dialog is canceled), a ValueError is raised.
 
         Args:
             title (str): The title of the dialog window.
@@ -258,10 +259,10 @@ class Window:
         """
         return self._impl.save_file_dialog(title, suggested_filename, file_types)
 
-    def open_file_dialog(self, title, initial_directory=None, file_types=None):
+    def open_file_dialog(self, title, initial_directory=None, file_types=None, multiselect=False):
         """ This opens a native dialog where the user can select the file to open.
         It is possible to set the initial folder and and only show files with specified file extensions.
-
+        If no path is returned (eg. dialog is canceled), a ValueError is raised.
         Args:
             title (str): The title of the dialog window.
             initial_directory(str): Initial folder displayed in the dialog.
@@ -270,5 +271,4 @@ class Window:
         Returns:
             The absolute path(str) to the selected file or None
         """
-        # Should we allow multiselect?
-        return self._impl.open_file_dialog(title, initial_directory, file_types)
+        return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -258,18 +258,17 @@ class Window:
         """
         return self._impl.save_file_dialog(title, suggested_filename, file_types)
 
+    def open_file_dialog(self, title, initial_directory=None, file_types=None):
+        """ This opens a native dialog where the user can select the file to open.
+        It is possible to set the initial folder and and only show files with specified file extensions.
 
-def open_file_dialog(self, title, initial_directory=None, file_types=None):
-    """ This opens a native dialog where the user can select the file to open.
-    It is possible to set the initial folder and and only show files with specified file extensions.
+        Args:
+            title (str): The title of the dialog window.
+            initial_directory(str): Initial folder displayed in the dialog.
+            file_types: A list of strings with the allowed file extensions.
 
-    Args:
-        title (str): The title of the dialog window.
-        initial_directory(str): Initial folder displayed in the dialog.
-        file_types: A list of strings with the allowed file extensions.
-
-    Returns:
-        The absolute path(str) to the selected file or None
-    """
-    # Should we allow multiselect?
-    return self._impl.save_file_dialog(title, initial_directory, file_types)
+        Returns:
+            The absolute path(str) to the selected file or None
+        """
+        # Should we allow multiselect?
+        return self._impl.open_file_dialog(title, initial_directory, file_types)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -261,14 +261,28 @@ class Window:
 
     def open_file_dialog(self, title, initial_directory=None, file_types=None, multiselect=False):
         """ This opens a native dialog where the user can select the file to open.
-        It is possible to set the initial folder and and only show files with specified file extensions.
+        It is possible to set the initial folder and only show files with specified file extensions.
         If no path is returned (eg. dialog is canceled), a ValueError is raised.
         Args:
             title (str): The title of the dialog window.
             initial_directory(str): Initial folder displayed in the dialog.
             file_types: A list of strings with the allowed file extensions.
+            multiselect: Value showing whether a user can select multiple files.
 
         Returns:
             The absolute path(str) to the selected file or None
         """
         return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)
+
+    def select_folder_dialog(self, title, initial_directory=None):
+        """ This opens a native dialog where the user can select a folder.
+        It is possible to set the initial folder.
+        If no path is returned (eg. dialog is canceled), a ValueError is raised.
+        Args:
+            title (str): The title of the dialog window.
+            initial_directory(str): Initial folder displayed in the dialog.
+
+        Returns:
+            The absolute path(str) to the selected file or None
+        """
+        return self._impl.select_folder_dialog(title, initial_directory)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -142,9 +142,17 @@ class Window:
         pass
 
     def save_file_dialog(self, title, suggested_filename, file_types):
-        self.interface.factory.not_implemented('Window.save_file_dialog()')
+        dialog = WinForms.SaveFileDialog()
+        dialog.Title = title
+        if suggested_filename is not None:
+            dialog.FileName = suggested_filename
+        if dialog.ShowDialog() == WinForms.DialogResult.OK:
+            return dialog.FileName
+        else:
+            return None
 
     def open_file_dialog(self, title, initial_directory, file_types):
+        print('Open file dialog')
         dialog = WinForms.OpenFileDialog()
         dialog.Title = title
         if initial_directory is not None:
@@ -152,6 +160,7 @@ class Window:
         if file_types is not None:
             # FIXME This is the example of Filter string: Text files (*.txt)|*.txt|All files (*.*)|*.*
             dialog.Filter = file_types
+        print('Dialog: ', dialog)
         if dialog.ShowDialog() == WinForms.DialogResult.OK:
             return dialog.FileName
         else:

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -143,3 +143,16 @@ class Window:
 
     def save_file_dialog(self, title, suggested_filename, file_types):
         self.interface.factory.not_implemented('Window.save_file_dialog()')
+
+    def open_file_dialog(self, title, initial_directory, file_types):
+        dialog = WinForms.OpenFileDialog()
+        dialog.Title = title
+        if initial_directory is not None:
+            dialog.InitialDirectory = initial_directory
+        if file_types is not None:
+            # FIXME This is the example of Filter string: Text files (*.txt)|*.txt|All files (*.*)|*.*
+            dialog.Filter = file_types
+        if dialog.ShowDialog() == WinForms.DialogResult.OK:
+            return dialog.FileName
+        else:
+            return None

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -167,3 +167,14 @@ class Window:
             return dialog.FileName
         else:
             raise ValueError("No filename provided in the open file dialog")
+
+    def select_folder_dialog(self, title, initial_directory):
+        dialog = WinForms.FolderBrowserDialog()
+        dialog.Title = title
+        if initial_directory is not None:
+            dialog.InitialDirectory = initial_directory
+
+        if dialog.ShowDialog() == WinForms.DialogResult.OK:
+            return dialog.SelectedPath
+        else:
+            raise ValueError("No folder provided in the select folder dialog")

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -149,17 +149,21 @@ class Window:
         if dialog.ShowDialog() == WinForms.DialogResult.OK:
             return dialog.FileName
         else:
-            return None
+            raise ValueError("No filename provided in the save file dialog")
 
-    def open_file_dialog(self, title, initial_directory, file_types):
+    def open_file_dialog(self, title, initial_directory, file_types, multiselect):
         dialog = WinForms.OpenFileDialog()
         dialog.Title = title
         if initial_directory is not None:
             dialog.InitialDirectory = initial_directory
         if file_types is not None:
             # FIXME This is the example of Filter string: Text files (*.txt)|*.txt|All files (*.*)|*.*
-            dialog.Filter = file_types
+
+            dialog.Filter = ';'.join(["*." + ext for ext in file_types]) + \
+                            "|All files (*.*)|*.*"
+        if multiselect:
+            dialog.Multiselect = True
         if dialog.ShowDialog() == WinForms.DialogResult.OK:
             return dialog.FileName
         else:
-            return None
+            raise ValueError("No filename provided in the open file dialog")

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -152,7 +152,6 @@ class Window:
             return None
 
     def open_file_dialog(self, title, initial_directory, file_types):
-        print('Open file dialog')
         dialog = WinForms.OpenFileDialog()
         dialog.Title = title
         if initial_directory is not None:
@@ -160,7 +159,6 @@ class Window:
         if file_types is not None:
             # FIXME This is the example of Filter string: Text files (*.txt)|*.txt|All files (*.*)|*.*
             dialog.Filter = file_types
-        print('Dialog: ', dialog)
         if dialog.ShowDialog() == WinForms.DialogResult.OK:
             return dialog.FileName
         else:


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I added `open_file_dialog` to the core `main_window` class, as well as Windows implementation for `open_file_dialog` and `save_file_dialog`. There are several things I'm not sure about: 

1. Windows allows multiselect when opening files. Should we add it?
2. What is the format of `file_types` sent to these dialogs? Is it something like `['txt', 'py']` or `['.txt', '.py']`?
3. Save file dialog should only provide the path where to save, saving itself should be done in the app, right? And the same is true with open file dialog, it only returns the full file name.
4. If the dialog is canceled, it returns `None`. Is this preferred behavior?

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
