### PR TITLE
DOC: fix little bug

### DIFF
--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -47,7 +47,7 @@ Alternatively, you can subclass App and implement the startup method
 
 
     if __name__ == '__main__':
-        app = MyApp('First App', 'org.pybee.helloworld', startup=build)
+        app = MyApp('First App', 'org.pybee.helloworld')
         app.main_loop()
 
 Reference


### PR DESCRIPTION
Delete `startup=build` arg in the docs. (`build` is not defined in this example and the `startup` method is used anyway.)
