### PR TITLE
Updated value property of MultilineTextInput, implemented in cocoa. Updated dummy and test case.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
+++ b/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
@@ -46,6 +46,9 @@ class MultilineTextInput(Widget):
     def set_readonly(self, value):
         self.text.editable = not self.interface._readonly
 
+    def get_value(self):
+        return self.text.string
+
     def set_value(self, value):
         self.text.string = self.interface._value
 

--- a/src/core/tests/widgets/test_multilinetextinput.py
+++ b/src/core/tests/widgets/test_multilinetextinput.py
@@ -16,7 +16,7 @@ class MultilineTextInputTests(TestCase):
 
     def test_multiline_properties_with_None(self):
         self.assertEqual(self.multiline.readonly, False)
-        self.assertEqual(self.multiline.value, '')  # TODO: shouldn't the value be self.initial in the beginning?
+        self.assertEqual(self.multiline.value, None)  # TODO: shouldn't the value be self.initial in the beginning?
         self.assertEqual(self.multiline.placeholder, '')
 
     def test_multiline_values(self):

--- a/src/core/toga/widgets/multilinetextinput.py
+++ b/src/core/toga/widgets/multilinetextinput.py
@@ -62,7 +62,7 @@ class MultilineTextInput(Widget):
         Returns:
             The text of the Widget as a ``str``.
         """
-        return self._value
+        return self._impl.get_value()
 
     @value.setter
     def value(self, value):

--- a/src/dummy/toga_dummy/widgets/multilinetextinput.py
+++ b/src/dummy/toga_dummy/widgets/multilinetextinput.py
@@ -8,6 +8,9 @@ class MultilineTextInput(Widget):
     def set_value(self, value):
         self._set_value('value', value)
 
+    def get_value(self):
+        return self._get_value('value')
+
     def set_placeholder(self, value):
         self._set_value('placeholder', value)
 

--- a/src/iOS/toga_iOS/widgets/multilinetextinput.py
+++ b/src/iOS/toga_iOS/widgets/multilinetextinput.py
@@ -117,7 +117,7 @@ class MultilineTextInput(Widget):
         self.native.text = self.interface._value
         self.placeholder_label.setHidden_(len(self.native.text) > 0)
 
-    def get_value(value):
+    def get_value(self):
         return self.native.text
 
     def rehint(self):

--- a/src/iOS/toga_iOS/widgets/multilinetextinput.py
+++ b/src/iOS/toga_iOS/widgets/multilinetextinput.py
@@ -34,7 +34,7 @@ class TogaMultilineTextView(UITextView, protocols=[UITextViewDelegate]):
     @objc_method
     def textViewShouldEndEditing_(self, text_view):
         return True
-    
+
     @objc_method
     def textViewDidBeginEditing_(self, text_view):
         self.placeholder_label.setHidden_(True)
@@ -47,7 +47,7 @@ class MultilineTextInput(Widget):
     def create(self):
         self.native = TogaMultilineTextView.alloc().init()
         self.native.delegate = self.native
-        
+
         # Placeholder isn't natively supported, so we create our
         # own
         self.placeholder_label = UILabel.alloc().init()
@@ -56,11 +56,11 @@ class MultilineTextInput(Widget):
         self.placeholder_label.alpha = 0.5
         self.native.addSubview_(self.placeholder_label)
         self.constrain_placeholder_label()
-        
+
         # Delegate needs to update the placeholder depending on
         # input, so we give it just that to avoid a retain cycle
         self.native.placeholder_label = self.placeholder_label
-        
+
         self.add_constraints()
 
     def constrain_placeholder_label(self):
@@ -116,6 +116,9 @@ class MultilineTextInput(Widget):
     def set_value(self, value):
         self.native.text = self.interface._value
         self.placeholder_label.setHidden_(len(self.native.text) > 0)
+
+    def get_value(value):
+        return self.native.text
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -21,7 +21,9 @@ class MultilineTextInput(Widget):
     def set_value(self, value):
         self.native.Text = value
 
+    def get_value(value):
+        return self.native.Text
+
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         self.interface.intrinsic.height = at_least(self.interface.MIN_HEIGHT)
-

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -21,7 +21,7 @@ class MultilineTextInput(Widget):
     def set_value(self, value):
         self.native.Text = value
 
-    def get_value(value):
+    def get_value(self):
         return self.native.Text
 
     def rehint(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

MultilineTextInput widget the “value” doesn’t change even if user types in the text box. The problem is that the interface layer (src/core/widgets/multilinetextinput.py) doesn’t make a call on the implementation layer (src/cocoa/widgets/multilinetextinput.py) on the value property.

Signed-off-by: Stanton Xu <xjiefeng@gmail.com>

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
