### PR TITLE
Make exit command call interface.exit()

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -104,7 +104,7 @@ class App:
             toga.Command(None, 'About ' + app_name, group=toga.Group.APP),
             toga.Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
-            toga.Command(lambda s: self.exit(), 'Quit ' + app_name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
+            toga.Command(lambda s: self.interface.exit(), 'Quit ' + app_name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
 
             toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
         )

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -133,7 +133,7 @@ class App:
             Command(None, 'About ' + self.interface.name, group=toga.Group.APP),
             Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
-            Command(lambda s: self.exit(), 'Quit ' + self.interface.name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
+            Command(lambda s: self.interface.exit(), 'Quit ' + self.interface.name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
             Command(None, 'Visit homepage', group=toga.Group.HELP)
         )
 

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -25,7 +25,7 @@ class App:
             toga.Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
             toga.Command(None, 'Preferences', group=toga.Group.FILE),
             # Quit should always be the last item, in a section on it's own
-            toga.Command(lambda s: self.exit(), 'Exit ' + self.interface.name, shortcut='q', group=toga.Group.FILE,
+            toga.Command(lambda s: self.interface.exit(), 'Exit ' + self.interface.name, shortcut='q', group=toga.Group.FILE,
                          section=sys.maxsize),
             toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
         )

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -20,12 +20,13 @@ class App:
 
     def create(self):
         self.native = WinForms.Application
-
+        self.native.ApplicationExit += self.exit_application
         self.interface.commands.add(
             toga.Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
             toga.Command(None, 'Preferences', group=toga.Group.FILE),
             # Quit should always be the last item, in a section on it's own
-            toga.Command(lambda s: self.interface.exit(), 'Exit ' + self.interface.name, shortcut='q', group=toga.Group.FILE,
+            toga.Command(lambda s: self.interface.exit(), 'Exit ' + self.interface.name, shortcut='q',
+                         group=toga.Group.FILE,
                          section=sys.maxsize),
             toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
         )
@@ -79,6 +80,9 @@ class App:
         thread.SetApartmentState(Threading.ApartmentState.STA)
         thread.Start()
         thread.Join()
+
+    def exit_application(self, sender, event):
+        self.interface.exit()
 
     def exit(self):
         self.native.Exit()


### PR DESCRIPTION
The `exit` method can now be overriden to add additional steps before exiting. Solves a bug mentioned in gitter by @stantonxu .

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
