### PR TITLE
detailedlist stub

### DIFF
--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -6,7 +6,7 @@ from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
-# from .widgets.detailedlist import DetailedList
+from .widgets.detailedlist import DetailedList
 from .widgets.icon import Icon
 # from .widgets.image import Image
 # from .widgets.imageview import ImageView
@@ -43,7 +43,7 @@ __all__ = [
     'Box',
     'Button',
     'Canvas',
-    # 'DetailedList',
+    'DetailedList',
     'Icon',
     # 'Image',
     # 'ImageView',

--- a/src/gtk/toga_gtk/widgets/detailedlist.py
+++ b/src/gtk/toga_gtk/widgets/detailedlist.py
@@ -2,54 +2,54 @@ from gi.repository import Gtk
 
 from .base import Widget
 
+
 class DetailedList(Widget):
-	def create(self):
-		self.native = Gtk.ScrolledWindow()
-		self.native.interface = self.interface
+    def create(self):
+        self.native = Gtk.ScrolledWindow()
+        self.native.interface = self.interface
 
-		#Craete DetailedList
-		self.vbox = Gtk.VBox()
+        # Create DetailedList
+        self.vbox = Gtk.VBox()
 
-		self.native.add_with_viewport(self.vbox)
+        self.native.add_with_viewport(self.vbox)
 
+    def change_source(self, source):
+        # TODO
+        raise NotImplementedError()
 
-	def change_source(self, source):
-		# TODO
-		raise NotImplementedError()
+    def insert(self, index, item):
+        # TODO
+        raise NotImplementedError()
 
-	def insert(self, index, item):
-		# TODO
-		raise NotImplementedError()
+    def change(self, item):
+        # TODO
+        raise NotImplementedError()
 
-	def change(self, item):
-		# TODO
-		raise NotImplementedError()
+    def remove(self, item):
+        # TODO
+        raise NotImplementedError()
 
-	def remove(self, item):
-		#TODO
-		raise NotImplementedError()
+    def clear(self):
+        # TODO
+        raise NotImplementedError()
 
-	def clear(self):
-		#TODO
-		raise NotImplementedError()
+    def set_on_refresh(self, handler):
+        pass
 
-	def set_on_refresh(self, handler):
-		pass
+    def after_on_refresh(self):
+        # TODO
+        raise NotImplementedError()
 
-	def after_on_refresh(self):
-		#TODO
-		raise NotImplementedError()
+    def set_on_select(self, handler):
+        pass
 
-	def set_on_select(self, handler):
-		pass
+    def set_on_delete(self, handler):
+        pass
 
-	def set_on_delete(self, handler):
-		pass
+    def scroll_to_row(self, row):
+        # TODO
+        raise NotImplementedError()
 
-	def scroll_to_row(self, row):
-		# TODO
-		raise NotImplementedError()
-
-	def rehint(self):
-		# TODO
-		raise NotImplementedError()
+    def rehint(self):
+        # TODO
+        raise NotImplementedError()

--- a/src/gtk/toga_gtk/widgets/detailedlist.py
+++ b/src/gtk/toga_gtk/widgets/detailedlist.py
@@ -15,30 +15,30 @@ class DetailedList(Widget):
 
     def change_source(self, source):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.change_source()')
 
     def insert(self, index, item):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.insert()')
 
     def change(self, item):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.change()')
 
     def remove(self, item):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.remove()')
 
     def clear(self):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.clear()')
 
     def set_on_refresh(self, handler):
         pass
 
     def after_on_refresh(self):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.after_on_refresh()')
 
     def set_on_select(self, handler):
         pass
@@ -48,8 +48,8 @@ class DetailedList(Widget):
 
     def scroll_to_row(self, row):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.scroll_to_row()')
 
     def rehint(self):
         # TODO
-        raise NotImplementedError()
+        self.interface.factory.not_implemented('DetailedList.rehint()')

--- a/src/gtk/toga_gtk/widgets/detailedlist.py
+++ b/src/gtk/toga_gtk/widgets/detailedlist.py
@@ -1,0 +1,55 @@
+from gi.repository import Gtk
+
+from .base import Widget
+
+class DetailedList(Widget):
+	def create(self):
+		self.native = Gtk.ScrolledWindow()
+		self.native.interface = self.interface
+
+		#Craete DetailedList
+		self.vbox = Gtk.VBox()
+
+		self.native.add_with_viewport(self.vbox)
+
+
+	def change_source(self, source):
+		# TODO
+		raise NotImplementedError()
+
+	def insert(self, index, item):
+		# TODO
+		raise NotImplementedError()
+
+	def change(self, item):
+		# TODO
+		raise NotImplementedError()
+
+	def remove(self, item):
+		#TODO
+		raise NotImplementedError()
+
+	def clear(self):
+		#TODO
+		raise NotImplementedError()
+
+	def set_on_refresh(self, handler):
+		pass
+
+	def after_on_refresh(self):
+		#TODO
+		raise NotImplementedError()
+
+	def set_on_select(self, handler):
+		pass
+
+	def set_on_delete(self, handler):
+		pass
+
+	def scroll_to_row(self, row):
+		# TODO
+		raise NotImplementedError()
+
+	def rehint(self):
+		# TODO
+		raise NotImplementedError()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR adds stubs for detailedlist for gtk interface
<!--- What problem does this change solve? -->
When using the detailedlist widget on linux, the user gets:
```
AttributeError: module 'toga_gtk.factory' has no attribute 'DetailedList'
```
This PR continues the work done in https://github.com/pybee/toga/pull/358 so that instead of a fatal/hard error, the below soft errors are raised and execution continues.
```
[GTK+] Not implemented: DetailedList.change_source()
...
[GTK+] Not implemented: DetailedList.rehint()
...
```

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This PR relates to https://github.com/pybee/toga/issues/338
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
