### PR TITLE
Add project urls to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,10 @@ setup(
         'Topic :: Software Development :: User Interfaces',
         'Topic :: Software Development :: Widget Sets',
     ],
+    package_urls={
+        'Funding': 'https://pybee.org/contributing/membership/',
+        'Documentation': 'https://toga.readthedocs.io/',
+        'Tracker': 'https://github.com/pybee/toga/issues',
+        'Source': 'https://github.com/pybee/toga',
+    },
 )


### PR DESCRIPTION
setup.py now defines a spec for project urls, which results in a more
informative pypi page and helps downstream consumers of project information.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
