### PR TITLE
Audit backends for consistency in "set_attribute()" pattern for base.enabled

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -30,7 +30,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        self.native.enabled = value
+        self.native.enabled = self.interface.enabled
 
     ### APPLICATOR
 

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -34,7 +34,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        self.native.enabled = value
+        self.native.enabled = self.interface.enabled
 
     ### APPLICATOR
 

--- a/src/core/tests/widgets/test_base.py
+++ b/src/core/tests/widgets/test_base.py
@@ -30,7 +30,7 @@ class WidgetTests(TestCase):
         box = toga.Box(factory=toga_dummy.factory)
         box.enabled = None
         self.assertFalse(box.enabled)
-        self.assertActionPerformedWith(box, 'set enabled', value=False)
+        self.assertActionPerformedWith(box, 'set enabled', value=None)
 
     def test_adding_children(self):
         """

--- a/src/core/tests/widgets/test_base.py
+++ b/src/core/tests/widgets/test_base.py
@@ -24,6 +24,13 @@ class WidgetTests(TestCase):
     def test_create_widget_with_no_style(self):
         widget = toga.Widget(factory=toga_dummy.factory)
         self.assertTrue(isinstance(widget.style, Pack))
+    
+    def test_enabled_with_None(self):
+        # Using a Box for test because we need a concrete implementation to use this property.
+        box = toga.Box(factory=toga_dummy.factory)
+        box.enabled = None
+        self.assertFalse(box.enabled)
+        self.assertActionPerformedWith(box, 'set enabled', value=False)
 
     def test_adding_children(self):
         """

--- a/src/django/toga_django/widgets/base.py
+++ b/src/django/toga_django/widgets/base.py
@@ -44,7 +44,7 @@ class Widget:
         self.interface.rehint()
 
     def set_enabled(self, value):
-        self.native.set_sensitive(value)
+        self.native.set_sensitive(self.interface.enabled)
 
     ### APPLICATOR
 

--- a/src/dummy/toga_dummy/widgets/base.py
+++ b/src/dummy/toga_dummy/widgets/base.py
@@ -24,7 +24,7 @@ class Widget(LoggedObject):
         self._set_value('container', container)
 
     def set_enabled(self, value):
-        self._action('set enabled', value=value)
+        self._action('set enabled', value=self.interface.enabled)
 
     ### APPLICATOR
 

--- a/src/dummy/toga_dummy/widgets/base.py
+++ b/src/dummy/toga_dummy/widgets/base.py
@@ -24,7 +24,7 @@ class Widget(LoggedObject):
         self._set_value('container', container)
 
     def set_enabled(self, value):
-        self._action('set enabled', value=self.interface.enabled)
+        self._action('set enabled', value=value)
 
     ### APPLICATOR
 

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -33,7 +33,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        self.native.set_sensitive(value)
+        self.native.set_sensitive(self.interface.enabled)
 
     ### APPLICATOR
 

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -33,7 +33,7 @@ class Widget:
         self.rehint()
 
     def set_enabled(self, value):
-        self.native.enabled = value
+        self.native.enabled = self.interface.enabled
 
     ### APPLICATOR
 


### PR DESCRIPTION
#299 
Updated base widget backends to use interface value when setting 'enabled'. Adds a test case to assert this happens in the dummy base widget using a dummy box widget.