### PR TITLE
OSX 10.7+ re-compatability

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -59,7 +59,10 @@ NSUnderlineStyleAttributeName = objc_const(appkit, "NSUnderlineStyleAttributeNam
 NSStrokeColorAttributeName = objc_const(appkit, "NSStrokeColorAttributeName")
 NSStrokeWidthAttributeName = objc_const(appkit, "NSStrokeWidthAttributeName")
 NSShadowAttributeName = objc_const(appkit, "NSShadowAttributeName")
-NSTextEffectAttributeName = objc_const(appkit, "NSTextEffectAttributeName")
+
+# NSTextEffectAttributeName is supported in OS 10.10+
+# goes against minimum requirements: current support is for OS 10.7+
+# NSTextEffectAttributeName = objc_const(appkit, "NSTextEffectAttributeName")
 
 NSAttachmentAttributeName = objc_const(appkit, "NSAttachmentAttributeName")
 NSLinkAttributeName = objc_const(appkit, "NSLinkAttributeName")

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -609,6 +609,8 @@ NSGrooveBorder = 3
 ######################################################################
 # NSWindow.h
 NSWindow = ObjCClass('NSWindow')
+NSWindow.declare_property('frame')
+
 
 NSBorderlessWindowMask = 0
 NSTitledWindowMask = 1 << 0

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -488,6 +488,7 @@ NSFileHandlingPanelOKButton = 1
 # NSScreen.h
 NSScreen = ObjCClass('NSScreen')
 NSScreen.declare_class_property('mainScreen')
+NSScreen.declare_property('visibleFrame')
 
 ######################################################################
 # NSScrollView.h

--- a/src/cocoa/toga_cocoa/libs/foundation.py
+++ b/src/cocoa/toga_cocoa/libs/foundation.py
@@ -17,6 +17,7 @@ foundation.NSMouseInRect.argtypes = [NSPoint, NSRect, c_bool]
 # NSBundle.h
 NSBundle = ObjCClass('NSBundle')
 NSBundle.declare_class_property('mainBundle')
+NSBundle.declare_property('bundlePath')
 
 ######################################################################
 # NSFileWrapper.h

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -108,7 +108,7 @@ class Window:
     def create(self):
         # OSX origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
-        screen = NSScreen.mainScreen.visibleFrame()
+        screen = NSScreen.mainScreen.visibleFrame
         position = NSMakeRect(
             screen.origin.x + self.interface.position[0],
             screen.size.height + screen.origin.y - self.interface.position[1] - self.interface._size[1],

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -108,7 +108,7 @@ class Window:
     def create(self):
         # OSX origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
-        screen = NSScreen.mainScreen.visibleFrame
+        screen = NSScreen.mainScreen.visibleFrame()
         position = NSMakeRect(
             screen.origin.x + self.interface.position[0],
             screen.size.height + screen.origin.y - self.interface.position[1] - self.interface._size[1],


### PR DESCRIPTION

## Overview
`NSTextEffectAttributeName` is only supported in OSX 10.10+. Currently the toga project supports OSX 10.7+.

It was discovered the `NSTextEffectAttributeName` is unused in the project. To solve the compatibility issues, reference to `NSTextEffectAttributeName` in `toga/src/cocoa/toga_cocoa/libs/appkit.py` has been commented out.

Further compatabiity has been through adding `NSBundle.declare_property('bundlePath')` and ` NSWindow.declare_property('frame') ` for backwards compatability.


### Solves - NSTextEffect error, Steps that generated error

As per toga setup instructions in the README:

Create a virtual machine `python3 -m venv venv` and activate with `. venv/bin/activate`

```
$ pip install pycairo
$ pip install pygobject

$ pip install toga-demo
$ toga-demo
```

```
$ cd toga/examples/tutorial0
$ python3 -m tutorial

$ pip install -e src/core
$ pip install -e src/cocoa
$ pip install -e src/dummy
```

### Error Generated

```
(venv) Moniques-MacBook-Air:tutorial0 Munnu$ python -m tutorial
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/examples/tutorial0/tutorial/__main__.py", line 4, in <module>
    main().main_loop()
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/examples/tutorial0/tutorial/app.py", line 20, in main
    return toga.App('First App', 'org.pybee.helloworld', startup=build)
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/core/toga/app.py", line 54, in __init__
    self.factory = get_platform_factory(factory)
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/core/toga/platform.py", line 36, in get_platform_factory
    from toga_cocoa import factory
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/cocoa/toga_cocoa/factory.py", line 1, in <module>
    from .app import App, MainWindow
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/cocoa/toga_cocoa/app.py", line 8, in <module>
    from .libs import *
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/cocoa/toga_cocoa/libs/__init__.py", line 1, in <module>
    from .appkit import *
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/cocoa/toga_cocoa/libs/appkit.py", line 62, in <module>
    NSTextEffectAttributeName = objc_const(appkit, "NSTextEffectAttributeName")
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/venv/lib/python3.6/site-packages/rubicon/objc/runtime.py", line 2185, in objc_const
    return ObjCInstance(objc_id.in_dll(dll, name))
ValueError: dlsym(0x7fda195348e0, NSTextEffectAttributeName): symbol not found
```