### PR TITLE
ImageView example provides rel path not working

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/image.py
+++ b/src/cocoa/toga_cocoa/widgets/image.py
@@ -9,7 +9,8 @@ class Image(object):
         self.interface = interface
         self.interface.impl = self
 
-    def __get_full_path(self, path):
+    @staticmethod
+    def _get_full_path(path):
         if path.startswith(('http://', 'https://')) or os.path.isabs(path):
             return path
         else:
@@ -19,4 +20,4 @@ class Image(object):
         if path.startswith(('http://', 'https://')):
             self.native = NSImage.alloc().initByReferencingURL(NSURL.URLWithString_(path))
         else:
-            self.native = NSImage.alloc().initWithContentsOfFile(self.__get_full_path(path))
+            self.native = NSImage.alloc().initWithContentsOfFile(self._get_full_path(path))

--- a/src/cocoa/toga_cocoa/widgets/image.py
+++ b/src/cocoa/toga_cocoa/widgets/image.py
@@ -1,3 +1,6 @@
+import os
+
+import toga
 from toga_cocoa.libs import *
 
 
@@ -6,8 +9,14 @@ class Image(object):
         self.interface = interface
         self.interface.impl = self
 
+    def __get_full_path(self, path):
+        if path.startswith(('http://', 'https://')) or os.path.isabs(path):
+            return path
+        else:
+            return os.path.join(toga.App.app_dir, path)
+
     def load_image(self, path):
-        if path.startswith('http://') or path.startswith('https://'):
+        if path.startswith(('http://', 'https://')):
             self.native = NSImage.alloc().initByReferencingURL(NSURL.URLWithString_(path))
         else:
-            self.native = NSImage.alloc().initWithContentsOfFile(path)
+            self.native = NSImage.alloc().initWithContentsOfFile(self.__get_full_path(path))

--- a/src/core/toga/widgets/image.py
+++ b/src/core/toga/widgets/image.py
@@ -5,7 +5,8 @@ class Image(object):
     """
 
     Args:
-        path (str): Path to the image.
+        path (str): Path to the image. Allowed values can be local file (relative or absolute path)
+            or URL (HTTP or HTTPS). Relative paths will be relative to `toga.App.app_dir`.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
     """

--- a/src/iOS/toga_iOS/widgets/image.py
+++ b/src/iOS/toga_iOS/widgets/image.py
@@ -1,21 +1,19 @@
 import os
+
 import toga
-from toga_iOS.libs import(
-    NSData,
-    NSURL,
-    UIImage
-)
+from toga_iOS.libs import NSURL, NSData, UIImage
+
 
 class Image(object):
     def __init__(self, interface):
         self.interface = interface
 
     def __get_full_path(self, path):
-        if (os.path.isabs(path)):
+        if path.startswith(('http://', 'https://')) or os.path.isabs(path):
             return path
         else:
             return os.path.join(toga.App.app_dir, path)
-    
+
     def load_image(self, path):
         # If a remote URL is provided, use the download from NSData (similar to toga-cocoa)
         if path.startswith('http://') or path.startswith('https://'):

--- a/src/iOS/toga_iOS/widgets/image.py
+++ b/src/iOS/toga_iOS/widgets/image.py
@@ -8,7 +8,8 @@ class Image(object):
     def __init__(self, interface):
         self.interface = interface
 
-    def __get_full_path(self, path):
+    @staticmethod
+    def _get_full_path(path):
         if path.startswith(('http://', 'https://')) or os.path.isabs(path):
             return path
         else:
@@ -19,4 +20,4 @@ class Image(object):
         if path.startswith('http://') or path.startswith('https://'):
             self.native = UIImage.imageWithData_(NSData.dataWithContentsOfURL_(NSURL.URLWithString_(path)))
         else:
-            self.native = UIImage.alloc().initWithContentsOfFile_(self.__get_full_path(path))
+            self.native = UIImage.alloc().initWithContentsOfFile_(self._get_full_path(path))


### PR DESCRIPTION
The ImageView example provides a relative path but Image.load_image
requires absolute path in Cocoa. This patch allows load_image to accept
a relative path.

Signed-off-by: William Clemens <wesclemens@gmail.com>

<!--- Describe your changes in detail -->
Will not resolve relative paths for Cocoa.

<!--- What problem does this change solve? -->
Image widget didn't resolve relative paths with Cocoa. This caused the exmpale imageview app to be broken.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
