### PR TITLE
OS 10.7+ compatability for non-editable text labels

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -564,6 +564,9 @@ def NSTextAlignment(alignment):
 NSTextField = ObjCClass('NSTextField')
 NSTextFieldCell = ObjCClass('NSTextFieldCell')
 
+NSTextField.declare_property('editable')
+NSTextField.declare_property('bezeled')
+
 ######################################################################
 # NSTextFieldCell.h
 


### PR DESCRIPTION
## Fixing text labels to be non-editable
In tutorial1 of the toga project for OS 10.7+ the text field option has been fixed to be non-editable. This required declaring `editable` and `bezeled` as properties for `NSTextField`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
