### PR TITLE
Os lion re compatability - NSToolbarItem itemIdentifier error

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -586,6 +586,7 @@ NSTimer = ObjCClass('NSTimer')
 NSToolbar = ObjCClass('NSToolbar')
 NSToolbarItem = ObjCClass('NSToolbarItem')
 
+NSToolbarItem.declare_property('itemIdentifier')
 ######################################################################
 # NSTrackingArea.h
 NSTrackingMouseEnteredAndExited = 0x01


### PR DESCRIPTION
## NSToolbarItem itemIdentifier error: Compatibility for OS 10.7+
Solved by adding declare_property for itemIdentifier in appkit.py to solve compatibility issues.

## Example Error

```
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 234, in 'calling callback function'
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/venv/lib/python3.6/site-packages/rubicon/objc/runtime.py", line 1033, in _objc_method
    result = f(py_self, *args)
  File "/Users/Munnu/Documents/gitrepo/pycon2018/beeware/toga/src/cocoa/toga_cocoa/window.py", line 89, in validateToolbarItem_
    return self.interface._impl._toolbar_items[item.itemIdentifier].enabled
KeyError: <exception str() failed>
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
