### PR TITLE
Add set_full_screen() stubs to window.py implementations

### DIFF
--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -55,7 +55,7 @@ class Window:
         pass
 
     def set_full_screen(self, is_full_screen):
-        pass
+        self.interface.factory.not_implemented('Window.set_full_screen()')
 
     def info_dialog(self, title, message):
         self.interface.factory.not_implemented('Window.info_dialog()')

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -54,6 +54,9 @@ class Window:
     def show(self):
         pass
 
+    def set_full_screen(self, is_full_screen):
+        pass
+
     def info_dialog(self, title, message):
         self.interface.factory.not_implemented('Window.info_dialog()')
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -206,6 +206,9 @@ class Window:
         # Refresh with the actual viewport to do the proper rendering.
         self.interface.content.refresh()
 
+    def set_full_screen(self, is_full_screen):
+        pass
+
     def on_close(self):
         pass
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -207,7 +207,7 @@ class Window:
         self.interface.content.refresh()
 
     def set_full_screen(self, is_full_screen):
-        pass
+        self.interface.factory.not_implemented('Window.set_full_screen()')
 
     def on_close(self):
         pass

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -34,3 +34,6 @@ class TestWindow(TestCase):
 
     def test_full_screen_set(self):
         self.assertEqual(self.window.full_screen, False)
+        is_full_screen = True
+        self.window.full_screen = is_full_screen
+        self.assertEqual(self.window.full_screen, is_full_screen)

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import toga
 import toga_dummy
 from toga.command import CommandSet
@@ -37,3 +39,11 @@ class TestWindow(TestCase):
         is_full_screen = True
         self.window.full_screen = is_full_screen
         self.assertEqual(self.window.full_screen, is_full_screen)
+
+    def test_set_size_with_content(self):
+        content = MagicMock()
+        size = (750, 1334)
+        self.window.content = content
+        self.window.size = size
+        self.assertEqual(size, self.window.size)
+        self.assertEqual(content, self.window.content)

--- a/src/django/toga_django/window.py
+++ b/src/django/toga_django/window.py
@@ -73,6 +73,9 @@ class Window(WindowInterface):
     def show(self):
         pass
 
+    def set_full_screen(self, is_full_screen):
+        pass
+
     def home(self, request):
         # app = self.app.materialize()
         # if app.main_window.id == self.id:

--- a/src/django/toga_django/window.py
+++ b/src/django/toga_django/window.py
@@ -74,7 +74,8 @@ class Window(WindowInterface):
         pass
 
     def set_full_screen(self, is_full_screen):
-        pass
+        self.interface.factory.not_implemented('Window.set_full_screen()')
+
 
     def home(self, request):
         # app = self.app.materialize()

--- a/src/dummy/toga_dummy/window.py
+++ b/src/dummy/toga_dummy/window.py
@@ -30,6 +30,9 @@ class Window(LoggedObject):
     def show(self):
         self._action('show')
 
+    def set_full_screen(self, is_full_screen):
+        self._set_value('is_full_screen', is_full_screen)
+
     @not_required_on('mobile')
     def on_close(self):
         self._action('handle Window on_close')

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -75,6 +75,9 @@ class Window:
         # Refresh with the actual viewport to do the proper rendering.
         self.interface.content.refresh()
 
+    def set_full_screen(self, is_full_screen):
+        pass
+
     def info_dialog(self, title, message):
         self.interface.factory.not_implemented('Window.info_dialog()')
 

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -76,7 +76,7 @@ class Window:
         self.interface.content.refresh()
 
     def set_full_screen(self, is_full_screen):
-        pass
+        self.interface.factory.not_implemented('Window.set_full_screen()')
 
     def info_dialog(self, title, message):
         self.interface.factory.not_implemented('Window.info_dialog()')

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -112,7 +112,7 @@ class Window:
             self.native.Show()
 
     def set_full_screen(self, is_full_screen):
-        pass
+        self.interface.factory.not_implemented('Window.set_full_screen()')
 
     def on_close(self):
         pass

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -111,6 +111,9 @@ class Window:
         if self.interface is not self.interface.app._main_window:
             self.native.Show()
 
+    def set_full_screen(self, is_full_screen):
+        pass
+
     def on_close(self):
         pass
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
EDIT: See comments below 

I added a setter method to toga_dummy\window.py for is_full_screen property. Then added a few lines to test_full_screen_set() so that it tests both reading and writing. If I understand correctly, an additional benefit of testing the setter method is to ensure the _impl method is invoked.

I'd like to continue working on this adding additional test for window.py, but would like to make sure I am on the right track, especially w.r.t changes/addition to toga_dummy\window.py

Best Regards,
Bob Marchese
<!--- What problem does this change solve? -->
Improves test coverage on window.py

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [x ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
