### PR TITLE
GTK file dialog implementation

### DIFF
--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -270,8 +270,7 @@ class Window:
             multiselect: Value showing whether a user can select multiple files.
 
         Returns:
-            The absolute path(str) to the selected file, a list(str)
-            if multiselect, or None
+            The absolute path(str) to the selected file or a list(str) if multiselect
         """
         return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)
 

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -270,7 +270,8 @@ class Window:
             multiselect: Value showing whether a user can select multiple files.
 
         Returns:
-            The absolute path(str) to the selected file or None
+            The absolute path(str) to the selected file, a list(str)
+            if multiselect, or None
         """
         return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)
 

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -1,6 +1,19 @@
 from gi.repository import Gtk
 
 
+def _set_filetype_filter(dialog, file_type):
+    '''Mutating function that Takes a dialog and inserts a Gtk.FileFilter
+
+    Args:
+        dialog: Gtk.FileChooserDialog to apply the filter
+        file_type: (str) the file type to filter
+    '''
+    filter_filetype = Gtk.FileFilter()
+    filter_filetype.set_name("." + file_type + " files")
+    filter_filetype.add_pattern("*." + file_type)
+    dialog.add_filter(filter_filetype)
+
+
 def info(window, title, message):
     dialog = Gtk.MessageDialog(window._impl.native, 0, Gtk.MessageType.INFO,
         Gtk.ButtonsType.OK, title)
@@ -55,10 +68,7 @@ def save_file(window, title, suggested_filename, file_types):
          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
 
     for x in file_types:
-        filter_filetype = Gtk.FileFilter()
-        filter_filetype.set_name("." + x + " files")
-        filter_filetype.add_pattern("*." + x)
-        dialog.add_filter(filter_filetype)
+        _set_filetype_filter(dialog, x)
 
     dialog.set_current_name(suggested_filename + "." + file_types[0])
 
@@ -69,3 +79,24 @@ def save_file(window, title, suggested_filename, file_types):
 
     dialog.destroy()
     return filename
+
+
+def open_file(window, title, file_types, multiselect):
+    filename_or_filenames = None
+    dialog = Gtk.FileChooserDialog(
+        title, window._impl.native,
+        Gtk.FileChooserAction.OPEN,
+        (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+         Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+    for file_type in file_types if file_types else ():
+        _set_filetype_filter(dialog, file_type)
+    if multiselect:
+        dialog.set_select_multiple()
+
+    response = dialog.run()
+
+    if response == Gtk.ResponseType.OK:
+        filename_or_filenames = (dialog.get_filenames() if multiselect else
+                                 dialog.get_filename())
+    dialog.destroy()
+    return file_or_files

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -99,4 +99,6 @@ def open_file(window, title, file_types, multiselect):
         filename_or_filenames = (dialog.get_filenames() if multiselect else
                                  dialog.get_filename())
     dialog.destroy()
+    if filename_or_filenames is None:
+        raise ValueError('No filename provided in the open file dialog')
     return filename_or_filenames

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -99,4 +99,4 @@ def open_file(window, title, file_types, multiselect):
         filename_or_filenames = (dialog.get_filenames() if multiselect else
                                  dialog.get_filename())
     dialog.destroy()
-    return file_or_files
+    return filename_or_filenames

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -91,7 +91,7 @@ def open_file(window, title, file_types, multiselect):
     for file_type in file_types if file_types else ():
         _set_filetype_filter(dialog, file_type)
     if multiselect:
-        dialog.set_select_multiple()
+        dialog.set_select_multiple(True)
 
     response = dialog.run()
 

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -143,3 +143,9 @@ class Window:
     def save_file_dialog(self, title, suggested_filename, file_types):
         return dialogs.save_file(self.interface, title, suggested_filename, file_types)
 
+    def open_file_dialog(self, title, initial_directory, file_types, multiselect):
+        '''Note that at this time, GTK does not recommend setting the initial
+        directory. This function explicitly chooses not to pass it along:
+        https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-folder
+        '''
+        return dialogs.open_file(self.interface, title, file_types, multiselect)


### PR DESCRIPTION
This work implements the GTK variant of the open file dialog, which was implemented for winforms in https://github.com/pybee/toga/pull/459.

I updated a few docstrings following the change in that PR mentioning that ValueError would be raised rather than returning None. A list is returned when the user selects multiple files.

The toga demo works as expected for GTK. Since the alternative flags aren't handled there, tried it out with a toy app locally and seemed to work fine with multiselect, file filters, etc. 

As a new contributor here, please point me to the right place to help with testing if this is desired! I also moved some repeated code to a `_set_filetype_filter` function, so let me know if `toga_gtk/dialogs.py` isn't the right place to keep this function.

## PR Checklist:
- [x] All new features have been tested <- "Tested" in a toy app, let me know if we want more here
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
