### PR TITLE
add select_folder_dialog to gtk

### DIFF
--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -88,7 +88,7 @@ def open_file(window, title, file_types, multiselect):
         Gtk.FileChooserAction.OPEN,
         (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
          Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
-    for file_type in file_types if file_types else ():
+    for file_type in file_types or []:
         _set_filetype_filter(dialog, file_type)
     if multiselect:
         dialog.set_select_multiple(True)
@@ -102,3 +102,23 @@ def open_file(window, title, file_types, multiselect):
     if filename_or_filenames is None:
         raise ValueError('No filename provided in the open file dialog')
     return filename_or_filenames
+
+
+def select_folder(window, title):
+    '''This function is very similar to the open_file function but more limited
+    in scope. If broadening scope here, or aligning features with the other
+    dialogs, consider refactoring around a common base function or set of
+    functions'''
+    filename = None
+    dialog = Gtk.FileChooserDialog(
+        title, window._impl.native,
+        Gtk.FileChooserAction.SELECT_FOLDER,
+        (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+         Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+    response = dialog.run()
+    if response == Gtk.ResponseType.OK:
+        filename = dialog.get_filename()
+    dialog.destroy()
+    if filename is None:
+        raise ValueError("No folder provided in the select folder dialog")
+    return filename

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -70,7 +70,8 @@ def save_file(window, title, suggested_filename, file_types):
     for x in file_types or []:
         _set_filetype_filter(dialog, x)
 
-    dialog.set_current_name(suggested_filename + "." + file_types[0])
+    dialog.set_current_name(suggested_filename if not file_types else
+                            suggested_filename + "." + file_types[0])
 
     response = dialog.run()
 

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -67,7 +67,7 @@ def save_file(window, title, suggested_filename, file_types):
         (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
 
-    for x in file_types:
+    for x in file_types or []:
         _set_filetype_filter(dialog, x)
 
     dialog.set_current_name(suggested_filename + "." + file_types[0])

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -67,8 +67,8 @@ def save_file(window, title, suggested_filename, file_types):
         (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
 
-    for x in file_types or []:
-        _set_filetype_filter(dialog, x)
+    for file_type in file_types or []:
+        _set_filetype_filter(dialog, file_type)
 
     dialog.set_current_name(suggested_filename if not file_types else
                             suggested_filename + "." + file_types[0])

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -149,3 +149,10 @@ class Window:
         https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-folder
         '''
         return dialogs.open_file(self.interface, title, file_types, multiselect)
+
+    def select_folder_dialog(self, title, initial_directory):
+        '''Note that at this time, GTK does not recommend setting the initial
+        directory. This function explicitly chooses not to pass it along:
+        https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-folder
+        '''
+        return dialogs.select_folder(self.interface, title)


### PR DESCRIPTION
Added the select_folder_dialog to gtk as well. It feels a bit repetitive compared to the other dialog functions--I initially tried to just cram an `is_folder` flag into the open_file function but that led to a few weird edge cases like passing file types to a folder dialog which felt less natural than just giving the folder dialog its own function.

Definitely open to suggestions here

EDIT: This PR also implements a small bugfix to the `save_file` dialog to handle the unused `file_types=None` case.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
