### PR TITLE
Fix intro text for 'switch'-widget

### DIFF
--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -10,7 +10,8 @@ Switch
 .. |y| image:: /_static/yes.png
     :width: 16
 
-The text input widget is a simple input field for user entry of text data.
+The switch widget is a clickable button with two stable states, True (on,
+checked) and False (off, unchecked).
 
 Usage
 -----


### PR DESCRIPTION
The intro text for the `switch` widget seemed to be copy and pasted from the text widget. This commit uses the docstring's text instead.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
