### PR TITLE
Edit MultilineTextInput example app

### DIFF
--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -1,11 +1,14 @@
 import toga
-from toga.style import Pack
 from toga.constants import COLUMN, ROW
+from toga.style import Pack
 
 
 class ExampleMultilineTextInputApp(toga.App):
     # Button callback functions
     def enable_toggle_pressed(self, widget, **kwargs):
+        self.multiline_input.enabled = not self.multiline_input.enabled
+
+    def readonly_toggle_pressed(self, widget, **kwargs):
         self.multiline_input.readonly = not self.multiline_input.readonly
 
     def clear_pressed(self, widget, **kwargs):
@@ -25,6 +28,11 @@ class ExampleMultilineTextInputApp(toga.App):
             on_press=self.enable_toggle_pressed,
             style=Pack(flex=1)
         )
+        button_toggle_readonly = toga.Button(
+            'Toggle readonly',
+            on_press=self.readonly_toggle_pressed,
+            style=Pack(flex=1)
+        )
         button_clear = toga.Button(
             'Clear',
             on_press=self.clear_pressed,
@@ -33,6 +41,7 @@ class ExampleMultilineTextInputApp(toga.App):
         btn_box = toga.Box(
             children=[
                 button_toggle_enabled,
+                button_toggle_readonly,
                 button_clear
             ],
             style=Pack(

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -1,6 +1,5 @@
-from travertino.size import at_least
-
 from toga_winforms.libs import WinForms
+from travertino.size import at_least
 
 from .base import Widget
 
@@ -12,7 +11,7 @@ class MultilineTextInput(Widget):
         self.native.Multiline = True
 
     def set_readonly(self, value):
-        self.native.ReadOnly = value
+        self.native.ReadOnly = self.interface.readonly
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

<!--- Describe your changes in detail -->
MultilineTextInput example app had a 'Toggle Enabled' button which was actually toggling `readonly` property of the MultilineTextInput. This caused issue #503. Now there are two buttons: to toggle both readonly and enabled properties.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
