### PR TITLE
GTK to raise error if image path is not valid

### DIFF
--- a/src/gtk/toga_gtk/widgets/imageview.py
+++ b/src/gtk/toga_gtk/widgets/imageview.py
@@ -29,7 +29,7 @@ class ImageView(Widget):
                 self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_stream(input_stream, None)
         full_image_path = self.image.path if os.path.isabs(self.image.path) else os.path.join(toga.App.app_dir, self.image.path)
         if os.path.isfile(full_image_path):
-            self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_file)
+            self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_file
         else:
             raise ValueError("No image file available at ", path)
         self.rehint()

--- a/src/gtk/toga_gtk/widgets/imageview.py
+++ b/src/gtk/toga_gtk/widgets/imageview.py
@@ -27,11 +27,11 @@ class ImageView(Widget):
             with urlopen(request) as result:
                 input_stream = Gio.MemoryInputStream.new_from_data(result.read(), None)
                 self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_stream(input_stream, None)
-        elif os.path.isabs(self.image.path):
-            self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_file(self.image.path)
+        full_image_path = self.image.path if os.path.isabs(self.image.path) else os.path.join(toga.App.app_dir, self.image.path)
+        if os.path.isfile(full_image_path):
+            self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_file)
         else:
-            self._original_pixbuf = GdkPixbuf.Pixbuf.new_from_file(os.path.join(toga.App.app_dir, self.image.path))
-
+            raise ValueError("No image file available at ", path)
         self.rehint()
 
     def rehint(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
If the image path is invalid, gtk backend raises a value error instead of crashing the app.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #529 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
