### PR TITLE
On_exit handler created in Cocoa, related to PR#522

### DIFF
--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -27,8 +27,9 @@ class CocoaViewport:
 class WindowDelegate(NSObject):
     @objc_method
     def windowWillClose_(self, notification) -> None:
-        if self.interface.app.on_exit:
-            self.interface.app.on_exit(self.interface.app)
+        if self.interface is self.interface.app._main_window:
+            if self.interface.app.on_exit:
+                self.interface.app.on_exit(self.interface.app)
         self.interface.on_close()
 
     @objc_method

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -27,6 +27,8 @@ class CocoaViewport:
 class WindowDelegate(NSObject):
     @objc_method
     def windowWillClose_(self, notification) -> None:
+        if self.interface.app.on_exit:
+            self.interface.app.on_exit(self.interface.app)
         self.interface.on_close()
 
     @objc_method


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR is to implement the on_exit handler in Cocoa, while PR#522 did it for Core and Winforms by @obulat 

Added the handler to windowWillClose, which is the native method triggered when window is closed

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #522 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct


Signed off by @stantonxu