### PR TITLE
On_exit handler called in app.py by applicationWillTerminate_

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -16,6 +16,11 @@ class MainWindow(Window):
 
 class AppDelegate(NSObject):
     @objc_method
+    def applicationWillTerminate_(self, sender):
+        if self.interface.app.on_exit:
+            self.interface.app.on_exit(self.interface.app)
+
+    @objc_method
     def applicationDidFinishLaunching_(self, notification):
         self.native.activateIgnoringOtherApps(True)
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -27,9 +27,10 @@ class CocoaViewport:
 class WindowDelegate(NSObject):
     @objc_method
     def windowWillClose_(self, notification) -> None:
-        if self.interface is self.interface.app._main_window:
-            if self.interface.app.on_exit:
-                self.interface.app.on_exit(self.interface.app)
+        # implement the on_exit handler call in app.py by applicationWillTerminate_ instead of here to avoid being called twice
+        # if self.interface is self.interface.app._main_window:
+        #     if self.interface.app.on_exit:
+        #         self.interface.app.on_exit(self.interface.app)
         self.interface.on_close()
 
     @objc_method

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -27,10 +27,6 @@ class CocoaViewport:
 class WindowDelegate(NSObject):
     @objc_method
     def windowWillClose_(self, notification) -> None:
-        # implement the on_exit handler call in app.py by applicationWillTerminate_ instead of here to avoid being called twice
-        # if self.interface is self.interface.app._main_window:
-        #     if self.interface.app.on_exit:
-        #         self.interface.app.on_exit(self.interface.app)
         self.interface.on_close()
 
     @objc_method


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
PR#535 implemented the on_exit handler, called by windowWillClose_ in window.py, but everytime with app is closed, on_exit handler will be called twice.

This PR moved the on_exit handler to applicationWillTerminate_ in app.py, to avoid the on_exit handler being called twice.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [*] All new features have been tested
- [ ] All new features have been documented
- [*] I have read the **CONTRIBUTING.md** file
- [*] I will abide by the code of conduct


Signed off by @stantonxu