### PR TITLE
Fix CTRL+q on GTK

### DIFF
--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -12,10 +12,19 @@ from toga.command import GROUP_BREAK, SECTION_BREAK, Command
 import toga
 from .window import Window
 from toga import Icon
-from toga.handlers import wrapped_handler
 
 import gbulb
 
+def _wrapped_activate(action):
+    """Handles the case where data is a second positional argument in an
+    activate action; since wrapped_handler takes **kwargs, it does not accept
+    positional arguments"""
+    def activate(widget, data=None):
+        if data is not None:
+            return action(widget, data=data)
+        else:
+            return action(widget)
+    return activate
 
 class MainWindow(Window):
     _IMPL_CLASS = Gtk.ApplicationWindow
@@ -115,7 +124,7 @@ class App:
                         cmd_id = "command-%s" % id(cmd)
                         action = Gio.SimpleAction.new(cmd_id, None)
                         if cmd.action:
-                            action.connect("activate", wrapped_handler(cmd, cmd.action))
+                            action.connect("activate", _wrapped_activate(cmd.action))
                         cmd._widgets.append(action)
                         self._actions[cmd] = action
                         self.native.add_action(action)


### PR DESCRIPTION
CTRL+q in GTK was raising the following error: `TypeError: _handler() takes 1 positional argument but 2 were given`. This boiled down to passing a wrapped_handler to the `activate` action. It seems that the activate action is called with a `data` positional argument rather than a named argument. Because of this, I defined an alternative wrapper used for this signal to handle this quirk of forwarding the additional argument. 

Similarly, since `Command.action`s are already wrapped with `wrapped_handler` in [command.py](https://github.com/pybee/toga/tree/59fbc518b18617235b1ff913f02f7e374244ee82/src/core/toga/command.py#L46-L49), I removed the redundant wrapping.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
