### PR TITLE
Fix for File Dialog Examples when Canceled

### DIFF
--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -44,7 +44,6 @@ class ExampledialogsApp(toga.App):
             save_path = self.main_window.save_file_dialog(
                 "Save file with Toga",
                 suggested_filename=fname)
-            print('save_path', save_path)
             if save_path is not None:
                 self.label.text = "File saved with Toga:" + save_path
             else:

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -21,31 +21,35 @@ class ExampledialogsApp(toga.App):
             self.main_window.info_dialog('Shucks...', "Well aren't you a spoilsport... :-(")
 
     def action_open_file_dialog(self, widget):
-        fname = self.main_window.open_file_dialog(
-            title="Open file with Toga",
-        )
         try:
+            fname = self.main_window.open_file_dialog(
+                title="Open file with Toga",
+            )
             self.label.text = "File to open:" + fname
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 
     def action_select_folder_dialog(self, widget):
-        path_name = self.main_window.select_folder_dialog(
-            title="Select folder with Toga",
-        )
         try:
+            path_name = self.main_window.select_folder_dialog(
+                title="Select folder with Toga",
+            )
             self.label.text = "Folder selected:" + path_name
         except ValueError:
             self.label.text = "Folder select dialog was canceled"
 
     def action_save_file_dialog(self, widget):
         fname = 'Toga_file.txt'
-        save_path = self.main_window.save_file_dialog(
-            "Save file with Toga",
-            suggested_filename=fname)
-        if save_path is not None:
-            self.label.text = "File saved with Toga:" + fname
-        else:
+        try:
+            save_path = self.main_window.save_file_dialog(
+                "Save file with Toga",
+                suggested_filename=fname)
+            print('save_path', save_path)
+            if save_path is not None:
+                self.label.text = "File saved with Toga:" + save_path
+            else:
+                self.label.text = "Save file dialog was canceled"
+        except ValueError:
             self.label.text = "Save file dialog was canceled"
 
     def startup(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
This PR is a proposed fix for the dialog examples. The open file, save file, and folder select each cause an error rather than showing the corresponding "canceled" message when the dialog is canceled or dismissed without selecting a file. I observed this behavior when running winforms and gtk.

Also, I believe there may be an issue in the underlying gtk code but I did not address it yet because I thought it would be better for this PR to stay focused on the example code. 

The "Save file dialog was canceled" message appears twice in the action_save_file_dialog() function. That is because winforms raises a ValueError while the gtk version does not. If you'd prefer, I could make make the the gtk dialogs.save_file() function also throw a ValueError when no filename is returned from the system dialog call. That would make the behavior consistent across the two implementations and allow the redundant message to be removed from the example. 

Please let me know what you think, and thanks for looking and my PR!

Best Regards,
Bob M
 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [ ] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
