### PR TITLE
add positional args to handlers

### DIFF
--- a/src/core/toga/handlers.py
+++ b/src/core/toga/handlers.py
@@ -20,9 +20,9 @@ async def long_running_task(generator, cleanup):
         traceback.print_exc()
 
 
-async def handler_with_cleanup(handler, cleanup, interface, **extra):
+async def handler_with_cleanup(handler, cleanup, interface, *args, **kwargs):
     try:
-        await handler(interface, **extra)
+        await handler(interface, *args, **kwargs)
         if cleanup:
             cleanup()
     except Exception as e:
@@ -46,13 +46,13 @@ def wrapped_handler(interface, handler, cleanup=None):
     the original handler function on the `_raw` attribute.
     """
     if handler:
-        def _handler(widget, **extra):
+        def _handler(widget, *args, **kwargs):
             if asyncio.iscoroutinefunction(handler):
                 asyncio.ensure_future(
-                    handler_with_cleanup(handler, cleanup, interface, **extra)
+                    handler_with_cleanup(handler, cleanup, interface, *args, **kwargs)
                 )
             else:
-                result = handler(interface, **extra)
+                result = handler(interface, *args, **kwargs)
                 if inspect.isgenerator(result):
                     asyncio.ensure_future(
                         long_running_task(result, cleanup)

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -57,7 +57,7 @@ class App:
             Command(None, 'About ' + self.interface.name, group=toga.Group.APP),
             Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
-            Command(lambda s: self.exit(), 'Quit ' + self.interface.name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
+            Command(lambda widget, data: self.exit(), 'Quit ' + self.interface.name, shortcut='q', group=toga.Group.APP, section=sys.maxsize),
             Command(None, 'Visit homepage', group=toga.Group.HELP)
         )
 


### PR DESCRIPTION
This solves the same problem as https://github.com/pybee/toga/pull/538 but it adds out the possibility of handlers to accept additional positional args. Additional positional args are required by GTK `activate` event handlers, it seems. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
