### PR TITLE
Adds some missing features to the winforms NumberInput and Selection …

### DIFF
--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -1,5 +1,7 @@
+import sys
 from toga_winforms.libs import LEFT, RIGHT, CENTER
 from toga_winforms.libs import WinForms, Convert, HorizontalTextAlignment
+from travertino.size import at_least
 
 from .base import Widget
 
@@ -7,24 +9,32 @@ from .base import Widget
 class NumberInput(Widget):
     def create(self):
         self.native = WinForms.NumericUpDown()
+        self.native.Value = Convert.ToDecimal(0.0)
 
     def set_readonly(self, value):
         self.native.ReadOnly = self.interface.readonly
 
     def set_step(self, step):
-        self.native.Increment = Convert.ToDecimal(self.interface.step)
+        self.native.Increment = Convert.ToDecimal(float(self.interface.step))
+        self.native.DecimalPlaces = abs(self.interface.step.as_tuple().exponent)
 
     def set_min_value(self, value):
-        if self.interface.min_value is not None:
+        if self.interface.min_value is None:
+            self.native.Minimum = Convert.ToDecimal(-sys.maxsize - 1)
+        else:
             self.native.Minimum = Convert.ToDecimal(self.interface.min_value)
 
     def set_max_value(self, value):
-        if self.interface.max_value is not None:
+        if self.interface.max_value is None:
+            self.native.Maximum = Convert.ToDecimal(sys.maxsize)
+        else:
             self.native.Maximum = Convert.ToDecimal(self.interface.max_value)
 
     def set_value(self, value):
-        if value is not None and value is not "":
-            self.native.Value = Convert.ToDecimal(self.interface.value)
+        if value is None or value is '':
+            self.native.Value = Convert.ToDecimal(0.0)
+        else:
+            self.native.Value = Convert.ToDecimal(float(self.interface.value))
 
     def set_alignment(self, value):
         self.native.TextAlign = HorizontalTextAlignment(value)
@@ -33,8 +43,13 @@ class NumberInput(Widget):
         self.interface.factory.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
-        self.interface.intrinsic.width = 120
-        self.interface.intrinsic.height = 32
+        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        self.interface.intrinsic.height = self.native.PreferredSize.Height
 
     def set_on_change(self, handler):
-        self.interface.factory.not_implemented('NumberInput.set_on_change()')
+        self.native.ValueChanged += self.on_number_change
+
+    def on_number_change(self, sender, event):
+        self.interface.value = Convert.ToString(sender.Value)
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)

--- a/src/winforms/toga_winforms/widgets/selection.py
+++ b/src/winforms/toga_winforms/widgets/selection.py
@@ -26,6 +26,10 @@ class Selection(Widget):
     def add_item(self, item):
         self.native.Items.Add(item)
 
+        # WinfForm.ComboBox does not select the first item, so it's done here.
+        if not self.get_selected_item():
+            self.native.SelectedIndex = 0
+
     def select_item(self, item):
         index = self.native.FindString(item)
         self.native.SelectedItem = index


### PR DESCRIPTION
…widgets

<!--- Describe your changes in detail -->
I wanted to run the traveltips app under windows but noticed there seemed to be a few things missing
from the NumberInput and Selection widgets. Specifically:

NumberInputs now has an on_change function added to the self.native.ValueChanged list and default min and max values following the GTK version's example. Also, the hard coded values in the rehint() function were replaced with code I found in TextInput.

The Selection widget now defaults to the first item in the list (again like GTK). It turns out that without this the travel tips app will crash trying to do the calculation without knowing which exchange rate to get from FOREX.

The code seems to work correctly, but I'm not that familiar with the WinForms environment I would not be surprised if I missed something. Please have a look and let me know if anything needs to be changed.

Thanks,
Bob M
   
<!--- What problem does this change solve? -->
These two widgets now behave more like GTK and hopefully other counterparts. The traveltips app (https://github.com/freakboy3742/traveltips) now runs under windows.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
