### PR TITLE
Example instruction updated to use the toga pre version on pypi

### DIFF
--- a/examples/beeliza/README.rst
+++ b/examples/beeliza/README.rst
@@ -15,5 +15,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m beeliza

--- a/examples/button/README.rst
+++ b/examples/button/README.rst
@@ -14,6 +14,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m button
-

--- a/examples/canvas/README.rst
+++ b/examples/canvas/README.rst
@@ -8,5 +8,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m canvas

--- a/examples/detailedlist/README.rst
+++ b/examples/detailedlist/README.rst
@@ -8,5 +8,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m detailedlist

--- a/examples/dialogs/README.rst
+++ b/examples/dialogs/README.rst
@@ -8,5 +8,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m dialogs

--- a/examples/imageview/README.rst
+++ b/examples/imageview/README.rst
@@ -9,12 +9,12 @@ parameters are set for height and width.
 
 The bottom image view has an image loaded from a remote URL. No
 style parameters are set so Pack should figure out how to use
-the remaining space. 
+the remaining space.
 
 Quickstart
 ~~~~~~~~~~
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m imageview

--- a/examples/multilinetextinput/README.rst
+++ b/examples/multilinetextinput/README.rst
@@ -9,5 +9,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m multilinetextinput

--- a/examples/progressbar/README.rst
+++ b/examples/progressbar/README.rst
@@ -12,6 +12,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m progressbar
-

--- a/examples/scrollcontainer/README.rst
+++ b/examples/scrollcontainer/README.rst
@@ -9,5 +9,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m scrollcontainer

--- a/examples/selection/README.rst
+++ b/examples/selection/README.rst
@@ -14,6 +14,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m selection
-

--- a/examples/slider/README.rst
+++ b/examples/slider/README.rst
@@ -13,6 +13,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m slider
-

--- a/examples/switch/README.rst
+++ b/examples/switch/README.rst
@@ -14,6 +14,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m switch
-

--- a/examples/table/README.rst
+++ b/examples/table/README.rst
@@ -8,5 +8,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m table

--- a/examples/table_source/README.rst
+++ b/examples/table_source/README.rst
@@ -12,5 +12,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m table_source

--- a/examples/tree/README.rst
+++ b/examples/tree/README.rst
@@ -8,5 +8,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m tree

--- a/examples/tree_source/README.rst
+++ b/examples/tree_source/README.rst
@@ -12,5 +12,5 @@ Quickstart
 
 To run this example:
 
-    $ pip install toga
+    $ pip install --pre toga
     $ python -m tree_source

--- a/examples/tutorial1/README.rst
+++ b/examples/tutorial1/README.rst
@@ -8,6 +8,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m tutorial
-

--- a/examples/tutorial2/README.rst
+++ b/examples/tutorial2/README.rst
@@ -8,6 +8,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m tutorial
-

--- a/examples/tutorial3/README.rst
+++ b/examples/tutorial3/README.rst
@@ -8,6 +8,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m tutorial
-

--- a/examples/tutorial4/README.rst
+++ b/examples/tutorial4/README.rst
@@ -8,6 +8,5 @@ Quickstart
 
 To run this example:
 
-    > pip install toga
+    > pip install --pre toga
     > python -m tutorial
-


### PR DESCRIPTION
The dev version on `pypi` introduces some new GUI packages, such as `style`. 

The examples in toga project rely on these new GUI packages, and it will run into some problems with the stable version on `pypi`, so the instructions need to be updated to use the dev version.

The change is from
```
pip install toga
```
to
```
pip install --pre toga
```

Fixes https://github.com/pybee/toga/issues/553

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
