### PR TITLE
Correct handling of filenames provided when the application is opened.

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -58,10 +58,10 @@ class AppDelegate(NSObject):
     def application_openFiles_(self, app, filenames) -> None:
         for i in range(0, len(filenames)):
             filename = filenames.objectAtIndex(i)
-            if isinstance(filename, str):
+            if isinstance(filename, NSString):
                 fileURL = NSURL.fileURLWithPath(filename)
 
-            elif filename.objc_class.name == 'NSURL':
+            elif isinstance(filename, NSURL):
                 # This case only exists because we aren't using the
                 # DocumentController to display the file open dialog.
                 # If we were, *all* filenames passed in would be


### PR DESCRIPTION
Correct the handling of documents in the Cocoa backend, accomodating recent changes to Rubicon around string and class handling.
