### PR TITLE
Bug Fixes to MultilineTextInput Widget for Gtk+

### DIFF
--- a/src/core/tests/widgets/test_multilinetextinput.py
+++ b/src/core/tests/widgets/test_multilinetextinput.py
@@ -8,7 +8,7 @@ class MultilineTextInputTests(TestCase):
         super().setUp()
 
         self.initial = 'Super Multiline Text'
-        self.multiline = toga.MultilineTextInput(self.initial, factory=toga_dummy.factory)
+        self.multiline = toga.MultilineTextInput(initial=self.initial, factory=toga_dummy.factory)
 
     def test_widget_created(self):
         self.assertEqual(self.multiline._impl.interface, self.multiline)
@@ -16,7 +16,7 @@ class MultilineTextInputTests(TestCase):
 
     def test_multiline_properties_with_None(self):
         self.assertEqual(self.multiline.readonly, False)
-        self.assertEqual(self.multiline.value, 'initial')
+        self.assertEqual(self.multiline.value, self.initial)
         self.assertEqual(self.multiline.placeholder, '')
 
     def test_multiline_values(self):

--- a/src/core/tests/widgets/test_multilinetextinput.py
+++ b/src/core/tests/widgets/test_multilinetextinput.py
@@ -16,7 +16,7 @@ class MultilineTextInputTests(TestCase):
 
     def test_multiline_properties_with_None(self):
         self.assertEqual(self.multiline.readonly, False)
-        self.assertEqual(self.multiline.value, None)  # TODO: shouldn't the value be self.initial in the beginning?
+        self.assertEqual(self.multiline.value, 'initial')
         self.assertEqual(self.multiline.placeholder, '')
 
     def test_multiline_values(self):

--- a/src/core/toga/widgets/multilinetextinput.py
+++ b/src/core/toga/widgets/multilinetextinput.py
@@ -23,7 +23,7 @@ class MultilineTextInput(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         self._impl = self.factory.MultilineTextInput(interface=self)
-        self.value = "initial"
+        self.value = initial
         self.readonly = readonly
         self.placeholder = placeholder
 
@@ -39,7 +39,7 @@ class MultilineTextInput(Widget):
     @placeholder.setter
     def placeholder(self, value):
         self._placeholder = '' if value is None else str(value)
-        self._impl.set_placeholder(value)
+        self._impl.set_placeholder(self._placeholder)
 
     @property
     def readonly(self):
@@ -67,7 +67,7 @@ class MultilineTextInput(Widget):
     @value.setter
     def value(self, value):
         self._value = '' if value is None else str(value)
-        self._impl.set_value(value)
+        self._impl.set_value(self._value)
         self._impl.rehint()
 
     def clear(self):

--- a/src/core/toga/widgets/multilinetextinput.py
+++ b/src/core/toga/widgets/multilinetextinput.py
@@ -23,7 +23,7 @@ class MultilineTextInput(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         self._impl = self.factory.MultilineTextInput(interface=self)
-        self.value = initial
+        self.value = "initial"
         self.readonly = readonly
         self.placeholder = placeholder
 

--- a/src/gtk/toga_gtk/widgets/multilinetextinput.py
+++ b/src/gtk/toga_gtk/widgets/multilinetextinput.py
@@ -1,5 +1,6 @@
-from gi.repository import Gtk
+from travertino.size import at_least
 
+from gi.repository import Gtk
 from .base import Widget
 
 


### PR DESCRIPTION
When trying to get Cricket to run with Gtk+, I ran cricket-unittest and was getting errors:
1. The initial value of the MultilineTextinput widget was not being set a string value
2. at_least was not being imported from travertino and was undefined

This PR fixes both of these issues.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
