### PR TITLE
Added dashed line support for canvas stroke

### DIFF
--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -138,8 +138,9 @@ class Canvas(Widget):
         self.apply_color(color, draw_context)
         draw_context.set_line_width(line_width)
         if line_dash is not None:
-            draw_context.set_dash(line_dash, 1)
+            draw_context.set_dash(line_dash)
         draw_context.stroke()
+        draw_context.set_dash([])
 
     # Transformations
 

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -134,9 +134,11 @@ class Canvas(Widget):
         else:
             draw_context.fill()
 
-    def stroke(self, color, line_width, draw_context, *args, **kwargs):
+    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         self.apply_color(color, draw_context)
         draw_context.set_line_width(line_width)
+        if line_dash is not None:
+            draw_context.set_dash(line_dash, 1)
         draw_context.stroke()
 
     # Transformations


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Added an argument line_dash for stroke which is called by set_dash to allow for dashed lines to be made in a canvas widget for gtk users. I'm not sure if this needs documentation as the PR Checklist indicates.

Fixes #581.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
