### PR TITLE
Remove unnecessary usages of `io` throughout

### DIFF
--- a/demo/setup.py
+++ b/demo/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./toga_demo/__init__.py', encoding='utf8') as version_file:
+with open('./toga_demo/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./toga_demo/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ copyright = u'2013, Russell Keith-Magee'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-import io, re
-with io.open('../src/core/toga/__init__.py', encoding='utf8') as version_file:
+import re
+with open('../src/core/toga/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         release = version_match.group(1)

--- a/docs/mock_gtk/setup.py
+++ b/docs/mock_gtk/setup.py
@@ -1,5 +1,4 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
@@ -13,7 +12,7 @@ from setuptools import setup, find_packages
 # *actually* doing anything.
 
 
-with io.open('../../src/gtk/toga_gtk/__init__.py', encoding='utf8') as version_file:
+with open('../../src/gtk/toga_gtk/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)

--- a/examples/.template/{{ cookiecutter.name }}/setup.py
+++ b/examples/.template/{{ cookiecutter.name }}/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./{{ cookiecutter.name }}/__init__.py', encoding='utf8') as version_file:
+with open('./{{ cookiecutter.name }}/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./{{ cookiecutter.name }}/__init__.py', encoding='utf8') as versio
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/beeliza/setup.py
+++ b/examples/beeliza/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./beeliza/__init__.py', encoding='utf8') as version_file:
+with open('./beeliza/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./beeliza/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/button/setup.py
+++ b/examples/button/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./button/__init__.py', encoding='utf8') as version_file:
+with open('./button/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./button/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/canvas/setup.py
+++ b/examples/canvas/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./canvas/__init__.py', encoding='utf8') as version_file:
+with open('./canvas/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./canvas/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/detailedlist/setup.py
+++ b/examples/detailedlist/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./detailedlist/__init__.py', encoding='utf8') as version_file:
+with open('./detailedlist/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./detailedlist/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/dialogs/setup.py
+++ b/examples/dialogs/setup.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./dialogs/__init__.py', encoding='utf8') as version_file:
+with open('./dialogs/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
     else:
         raise RuntimeError("Unable to find version string.")
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 setup(

--- a/examples/imageview/setup.py
+++ b/examples/imageview/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./imageview/__init__.py', encoding='utf8') as version_file:
+with open('./imageview/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./imageview/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/multilinetextinput/setup.py
+++ b/examples/multilinetextinput/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./multilinetextinput/__init__.py', encoding='utf8') as version_file:
+with open('./multilinetextinput/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./multilinetextinput/__init__.py', encoding='utf8') as version_fil
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/progressbar/setup.py
+++ b/examples/progressbar/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-import io
 import re
 from setuptools import setup, find_packages
 
-with io.open('./progressbar/__init__.py', encoding='utf8') as version_file:
+with open('./progressbar/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -11,7 +10,7 @@ with io.open('./progressbar/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/scrollcontainer/setup.py
+++ b/examples/scrollcontainer/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./scrollcontainer/__init__.py', encoding='utf8') as version_file:
+with open('./scrollcontainer/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./scrollcontainer/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/selection/setup.py
+++ b/examples/selection/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./selection/__init__.py', encoding='utf8') as version_file:
+with open('./selection/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./selection/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/slider/setup.py
+++ b/examples/slider/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./slider/__init__.py', encoding='utf8') as version_file:
+with open('./slider/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./slider/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/switch/setup.py
+++ b/examples/switch/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./switch/__init__.py', encoding='utf8') as version_file:
+with open('./switch/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./switch/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/table/setup.py
+++ b/examples/table/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./table/__init__.py', encoding='utf8') as version_file:
+with open('./table/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./table/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/table_source/setup.py
+++ b/examples/table_source/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./table_source/__init__.py', encoding='utf8') as version_file:
+with open('./table_source/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./table_source/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tree/setup.py
+++ b/examples/tree/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tree/__init__.py', encoding='utf8') as version_file:
+with open('./tree/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tree/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tree_source/setup.py
+++ b/examples/tree_source/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tree_source/__init__.py', encoding='utf8') as version_file:
+with open('./tree_source/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tree_source/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tutorial0/setup.py
+++ b/examples/tutorial0/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
+with open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tutorial1/setup.py
+++ b/examples/tutorial1/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
+with open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tutorial2/setup.py
+++ b/examples/tutorial2/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
+with open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tutorial3/setup.py
+++ b/examples/tutorial3/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
+with open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/examples/tutorial4/setup.py
+++ b/examples/tutorial4/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
+with open('./tutorial/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('./tutorial/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 from setuptools import setup
 
 
-with io.open('src/core/toga/__init__.py', encoding='utf8') as version_file:
+with open('src/core/toga/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('src/core/toga/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_android/__init__.py', encoding='utf8') as version_file:
+with open('toga_android/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_android/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/cocoa/setup.py
+++ b/src/cocoa/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_cocoa/__init__.py', encoding='utf8') as version_file:
+with open('toga_cocoa/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_cocoa/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga/__init__.py', encoding='utf8') as version_file:
+with open('toga/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -35,7 +35,7 @@ class Icon:
     @property
     def filename(self):
         if self.system:
-            toga_dir = os.path.dirname(os.path.dirname(__file__))
+            toga_dir = os.path.dirname(__file__)
             return os.path.join(toga_dir, 'resources', self.path)
         else:
             from toga.app import App

--- a/src/curses/setup.py
+++ b/src/curses/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_curses/__init__.py', encoding='utf8') as version_file:
+with open('toga_curses/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_curses/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/django/setup.py
+++ b/src/django/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_django/__init__.py', encoding='utf8') as version_file:
+with open('toga_django/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_django/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/dummy/setup.py
+++ b/src/dummy/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_dummy/__init__.py', encoding='utf8') as version_file:
+with open('toga_dummy/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_dummy/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/flask/setup.py
+++ b/src/flask/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_flask/__init__.py', encoding='utf8') as version_file:
+with open('toga_flask/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_flask/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/gtk/setup.py
+++ b/src/gtk/setup.py
@@ -1,11 +1,10 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
 
-with io.open('toga_gtk/__init__.py', encoding='utf8') as version_file:
+with open('toga_gtk/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -13,7 +12,7 @@ with io.open('toga_gtk/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/iOS/setup.py
+++ b/src/iOS/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_iOS/__init__.py', encoding='utf8') as version_file:
+with open('toga_iOS/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_iOS/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/pyramid/setup.py
+++ b/src/pyramid/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_pyramid/__init__.py', encoding='utf8') as version_file:
+with open('toga_pyramid/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_pyramid/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/qt/setup.py
+++ b/src/qt/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_qt/__init__.py', encoding='utf8') as version_file:
+with open('toga_qt/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_qt/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/tvOS/setup.py
+++ b/src/tvOS/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_tvOS/__init__.py', encoding='utf8') as version_file:
+with open('toga_tvOS/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_tvOS/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('src/tvOS/README.rst', encoding='utf8') as readme:
+with open('src/tvOS/README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/uwp/setup.py
+++ b/src/uwp/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_uwp/__init__.py', encoding='utf8') as version_file:
+with open('toga_uwp/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_uwp/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/watchOS/setup.py
+++ b/src/watchOS/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_watchOS/__init__.py', encoding='utf8') as version_file:
+with open('toga_watchOS/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_watchOS/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/web/setup.py
+++ b/src/web/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_web/__init__.py', encoding='utf8') as version_file:
+with open('toga_web/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_web/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/win32/setup.py
+++ b/src/win32/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_win32/__init__.py', encoding='utf8') as version_file:
+with open('toga_win32/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_win32/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -1,10 +1,9 @@
 #/usr/bin/env python
-import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_winforms/__init__.py', encoding='utf8') as version_file:
+with open('toga_winforms/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)
@@ -12,7 +11,7 @@ with io.open('toga_winforms/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
 

--- a/src/winforms/toga_winforms/colors.py
+++ b/src/winforms/toga_winforms/colors.py
@@ -1,4 +1,4 @@
-from ..libs import Color
+from toga_winforms.libs import Color
 
 CACHE = {}
 

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 from toga_winforms.libs import WinForms
-from toga_winforms.resources.colors import native_color
+from toga_winforms.colors import native_color
 from .base import Widget
 
 


### PR DESCRIPTION
Remove usages of the following;
* `import io`
* \<function\> `io.open`
> Prefer \<built-in function\> `open`
>> `io.open` is typically used to allow opening a file with an explicit encoding in Python 2.x. Since we explicitly don't allow Python 2.x, this usage is pointless and can be replaced with `open` to achieve the same functionality with 1 less `import` throughout the project.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
