### PR TITLE
Revert usage of WKWebView on Cocoa.

### DIFF
--- a/src/cocoa/toga_cocoa/libs/webkit.py
+++ b/src/cocoa/toga_cocoa/libs/webkit.py
@@ -10,5 +10,9 @@ webkit = cdll.LoadLibrary(util.find_library('WebKit'))
 ######################################################################
 
 ######################################################################
+# WebView.h
+WebView = ObjCClass('WebView')
+
+######################################################################
 # WKWebView.h
 WKWebView = ObjCClass('WKWebView')

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -2,12 +2,12 @@ from travertino.size import at_least
 from rubicon.objc import objc_method
 
 from toga_cocoa.keys import toga_key
-from toga_cocoa.libs import NSURL, NSURLRequest, WKWebView
+from toga_cocoa.libs import NSURL, NSURLRequest, WebView
 
 from .base import Widget
 
 
-class TogaWebView(WKWebView):
+class TogaWebView(WebView):
     @objc_method
     def webView_didFinishLoadForFrame_(self, sender, frame) -> None:
         if self.interface.on_webview_load:
@@ -47,16 +47,16 @@ class WebView(Widget):
         # Utilises Step 2) of:
         # https://developer.apple.com/library/content/documentation/
         #       Cocoa/Conceptual/DisplayWebContent/Tasks/SaveAndLoad.html
-        html = self.native.DOMDocument.documentElement.outerHTML
+        html = self.native.mainframe.DOMDocument.documentElement.outerHTML
         return html
 
     def set_url(self, value):
         if value:
             request = NSURLRequest.requestWithURL(NSURL.URLWithString(self.interface.url))
-            self.native.loadRequest(request)
+            self.native.mainFrame.loadRequest(request)
 
     def set_content(self, root_url, content):
-        self.native.loadHTMLString_baseURL_(content, NSURL.URLWithString(root_url))
+        self.native.mainFrame.loadHTMLString(content, baseURL=NSURL.URLWithString(root_url))
 
     def set_user_agent(self, value):
         self.native.customUserAgent = value if value else "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"  # NOQA


### PR DESCRIPTION
WKWebView isn't quite ready for prime time on cocoa, due to handling of file URLs.
