### PR TITLE
Changed references from python or python3 to py for Windows in docs

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -182,7 +182,7 @@ To run the app you'll need to execute the correct command for your platform from
 
     .. code-block:: doscon
 
-      (venv) C:\...>python -m helloworld
+      (venv) C:\...>py -m helloworld
 
 This should pop up a window with a button:
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -38,8 +38,8 @@ start coding. To set up a virtual environment, run:
 
     .. code-block:: doscon
 
-      C:\...>python3 -m venv venv
-      C:\...>venv\Scripts\activate
+      C:\...>py -m venv venv
+      C:\...>venv\Scripts\activate.bat
 
 Your prompt should now have a ``(venv)`` prefix in front of it. 
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -63,7 +63,7 @@ Next, install Toga into your virtual environment:
 
     .. code-block:: doscon
 
-      (venv) C:\...>pip install --pre toga
+      (venv) C:\...>py -m pip install --pre toga
 
 After a successful installation of Toga you are ready to get coding.
 


### PR DESCRIPTION
for windows.

On Windows, Python is not installed on the system path by default.  For this reason, Python for Windows has the Python launcher, invoked as "py" on the command line, and "py -m" to use the script as an imported module. Also, the script to activate the virtual enviroment in Windows for both venv and virtualenv is <name_of_virtualenv>\Scripts\activate.bat

This will make tutorial work correctly whether or not the python interpreter is on the path.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
