### PR TITLE
Changed invocations for Windows users before venv is activated

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -38,7 +38,7 @@ start coding. To set up a virtual environment, run:
 
     .. code-block:: doscon
 
-      C:\...>python3 -m venv venv
+      C:\...>py -m venv venv
       C:\...>venv\Scripts\activate
 
 Your prompt should now have a ``(venv)`` prefix in front of it. 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -39,7 +39,7 @@ start coding. To set up a virtual environment, run:
     .. code-block:: doscon
 
       C:\...>py -m venv venv
-      C:\...>venv\Scripts\activate
+      C:\...>venv\Scripts\activate.bat
 
 Your prompt should now have a ``(venv)`` prefix in front of it. 
 


### PR DESCRIPTION

Changed Python invocation for Windows to py to use the Python launcher 
Changed activate to activate.bat to activate venv in Windows 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
