### PR TITLE
docs(tutorial0): fixes #568

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -124,7 +124,9 @@ on all sides. If we wanted to define padding of 20 pixels on top of the
 button, we could have defined ``padding_top = 20``, or we could have specified
 the ``padding = (20, 50, 50, 50)``.
 
-        button.style.flex = 1
+Now we will make the button take up all the available width::
+
+       button.style.flex = 1
 
 `flex` property specifies how an element is sized with respect to other
 elements along its direction. The default direction is row (horizontal) and

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -128,11 +128,11 @@ Now we will make the button take up all the available width::
 
        button.style.flex = 1
 
-`flex` property specifies how an element is sized with respect to other
+``flex`` attribute specifies how an element is sized with respect to other
 elements along its direction. The default direction is row (horizontal) and
 since the button is the only element here, it will take up the whole width.
-Check out https://toga.readthedocs.io/en/latest/reference/style/pack.html#flex
-for more information on how to use the `flex` property.
+Check out `style docs <https://toga.readthedocs.io/en/latest/reference/style/pack.html#flex>`_
+for more information on how to use the ``flex`` attribute.
 
 The next step is to add the button to the box::
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -41,7 +41,7 @@ start coding. To set up a virtual environment, run:
       C:\...>py -m venv venv
       C:\...>venv\Scripts\activate.bat
 
-Your prompt should now have a ``(venv)`` prefix in front of it. 
+Your prompt should now have a ``(venv)`` prefix in front of it.
 
 Next, install Toga into your virtual environment:
 
@@ -124,13 +124,19 @@ on all sides. If we wanted to define padding of 20 pixels on top of the
 button, we could have defined ``padding_top = 20``, or we could have specified
 the ``padding = (20, 50, 50, 50)``.
 
+        button.style.flex = 1
+
+`flex` property specifies how an element is sized with respect to other
+elements along its direction. The default direction is row (horizontal) and
+since the button is the only element here, it will take up the whole width.
+Check out https://toga.readthedocs.io/en/latest/reference/style/pack.html#flex
+for more information on how to use the `flex` property.
+
 The next step is to add the button to the box::
 
         box.add(button)
 
-The button will, by default, stretch to the size of the box it is placed in.
-The outer box will also stretch to the size of box it is placed in - which, in
-our case, is the window itself. The button has a default height, defined by
+The button has a default height, defined by
 the way that the underlying platform draws buttons). As a result, this means
 we'll see a single button in the app window that stretches to the width of the
 screen, but has a 50 pixel space surrounding it.
@@ -197,7 +203,7 @@ app will have a default Toga icon (a picture of Tiberius the yak).
 Troubleshooting issues
 ----------------------
 
-Occasionally you might run into issues running Toga on your computer. 
+Occasionally you might run into issues running Toga on your computer.
 
 Before you run the app, you'll need to install toga. Although you *can* install
 toga by just running::


### PR DESCRIPTION
First-time contributor! Love the work! (Please forgive me for any noobie mistakes) 
Added docs for `button.style.flex = 1` in [tutorial 0](https://toga.readthedocs.io/en/latest/tutorial/tutorial-0.html#write-the-app) with the correct [link](https://toga.readthedocs.io/en/latest/reference/style/pack.html#flex) to main docs. ( Fixes #568 ). 
I have also removed a couple of sentences below that says the button would take up the whole width by default, as this is actually a bit misleading. (I tried it without applying flex 1, attaching screenshot).

<img width="644" alt="screenshot 2019-01-20 at 9 06 35 pm" src="https://user-images.githubusercontent.com/8216048/51441480-28979280-1cf8-11e9-971c-d3a1bc1d13f6.png">


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
