### PR TITLE
imageview example fixes #533, #606

### DIFF
--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -14,7 +14,7 @@ class ImageViewApp(toga.App):
         # image from local path
         # load brutus.png from the package
         # We set the style width/height parameters for this one
-        image_from_path = toga.Image('resources/brutus.png')
+        image_from_path = toga.Image('../resources/brutus.png')
         imageview_from_path = toga.ImageView(image_from_path)
         imageview_from_path.style.update(height=72)
         imageview_from_path.style.update(width=72)


### PR DESCRIPTION
fixes #533,  #606 both issues

 The path was looking for the image in the current directory instead of the parent one. The imageview example wanted the image which was in the resources folder of the parent directory but was looking for it in the current directory which had no such folder.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
