### PR TITLE
toga-GTK: Fixed Textinput implementation to add the change handler, a…

### DIFF
--- a/src/gtk/toga_gtk/widgets/passwordinput.py
+++ b/src/gtk/toga_gtk/widgets/passwordinput.py
@@ -5,7 +5,5 @@ from .textinput import TextInput
 
 class PasswordInput(TextInput):
     def create(self):
-        self.native = Gtk.Entry()
-        self.native.interface = self.interface
+        super().create()
         self.native.set_visibility(False)
-        self.native.connect('show', lambda event: self.rehint())

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -8,8 +8,12 @@ class TextInput(Widget):
     def create(self):
         self.native = Gtk.Entry()
         self.native.interface = self.interface
-
         self.native.connect('show', lambda event: self.rehint())
+        self.native.connect('changed', self._on_change)
+
+    def _on_change(self, entry):
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)
 
     def set_readonly(self, value):
         self.native.set_property('editable', not value)


### PR DESCRIPTION
…nd updated Passwordinput to use super.create

Signed-off-by: Moises <moises.aranas@gmail.com>

The GTK implementation of Textinput is missing the on_change handler, this commit adds that hadler to Textinput and also updates Passwordinput to properly use the super.create method it inherits from Textinput

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
